### PR TITLE
Added ability to use IMGUI_API for exports when used from a DLL/.so

### DIFF
--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -103,20 +103,27 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 #endif
 #pragma once
 
+#ifdef USE_IMGUI_API
+#include "imconfig.h"
+#endif
+#ifndef IMGUI_API
+#define IMGUI_API
+#endif
+
 namespace ImGuizmo
 {
 	// call BeginFrame right after ImGui_XXXX_NewFrame();
-	void BeginFrame();
+	IMGUI_API void BeginFrame();
 
 	// return true if mouse cursor is over any gizmo control (axis, plan or screen component)
-	bool IsOver();
+	IMGUI_API bool IsOver();
 
 	// return true if mouse IsOver or if the gizmo is in moving state
-	bool IsUsing();
+	IMGUI_API bool IsUsing();
 
 	// enable/disable the gizmo. Stay in the state until next call to Enable.
 	// gizmo is rendered with gray half transparent color when disabled
-	void Enable(bool enable);
+	IMGUI_API void Enable(bool enable);
 
 	// helper functions for manualy editing translation/rotation/scale with an input float
 	// translation, rotation and scale float points to 3 floats each
@@ -130,13 +137,13 @@ namespace ImGuizmo
 	// ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, gizmoMatrix.m16);
 	//
 	// These functions have some numerical stability issues for now. Use with caution.
-	void DecomposeMatrixToComponents(const float *matrix, float *translation, float *rotation, float *scale);
-	void RecomposeMatrixFromComponents(const float *translation, const float *rotation, const float *scale, float *matrix);
+	IMGUI_API void DecomposeMatrixToComponents(const float *matrix, float *translation, float *rotation, float *scale);
+	IMGUI_API void RecomposeMatrixFromComponents(const float *translation, const float *rotation, const float *scale, float *matrix);
 
-	void SetRect(float x, float y, float width, float height);
+	IMGUI_API void SetRect(float x, float y, float width, float height);
 
 	// Render a cube with face color corresponding to face normal. Usefull for debug/tests
-	void DrawCube(const float *view, const float *projection, float *matrix);
+	IMGUI_API void DrawCube(const float *view, const float *projection, float *matrix);
 
 	// call it when you want a gizmo
 	// Needs view and projection matrices. 
@@ -155,5 +162,5 @@ namespace ImGuizmo
 		WORLD
 	};
 
-	void Manipulate(const float *view, const float *projection, OPERATION operation, MODE mode, float *matrix, float *deltaMatrix = 0, float *snap = 0, float *localBounds = NULL, float *boundsSnap = NULL);
+	IMGUI_API void Manipulate(const float *view, const float *projection, OPERATION operation, MODE mode, float *matrix, float *deltaMatrix = 0, float *snap = 0, float *localBounds = NULL, float *boundsSnap = NULL);
 };


### PR DESCRIPTION
For use in [RuntimeCompiled C++](https://github.com/RuntimeCompiledCPlusPlus/RuntimeCompiledCPlusPlus) it's a lot easier for me to use ImGuizmo in a DLL as it has hidden state, so when a runtime compile is issued the main exe and runtime compiled code have different versions of the object files linked in and so different states.

I imagine this is useful in general, and all that's needed is defininng USE_IMGUI_API to use in the same DLL as ImGui, or define IMGUI_API yourself.

An alternative might be an IMGUIZMO_API which can be set to IMGUI_API or other.