### PR TITLE
Multi bounds

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1081,9 +1081,9 @@ namespace ImGuizmo
 				   bestAxisWorldDirection = dirPlaneNormalWorld;
 			   }
 
-			   if( dt >= 0.3f )
+			   if( dt >= 0.1f )
 			   {
-				   axes[numAxes] = bestAxis;
+				   axes[numAxes] = i;
 				   axesWorldDirections[numAxes] = dirPlaneNormalWorld;
 				   ++numAxes;
 			   }


### PR DESCRIPTION
This PR is on top of the changes for screen rect bounds checking. I can remove the rect bounds check code if this is needed separately.

This adds multiple bounds axis handles based on a heuristic dot product of more than 0.1f. The value could be a context config parameter but for now it's inlined in the code. The code then loops around drawing each axis in turn, ensuring the topmost axis is the best aligned for user interaction - though a full sort might be better.

See https://twitter.com/dougbinks/status/917356318259892224 for a video of this in action.