### PR TITLE
Alt translate plan normal

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1451,8 +1451,22 @@ namespace ImGuizmo
             gContext.mbUsing = true;
             gContext.mCurrentOperation = type;
             const vec_t movePlanNormal[] = { gContext.mModel.v.up, gContext.mModel.v.dir, gContext.mModel.v.right, gContext.mModel.v.dir, gContext.mModel.v.right, gContext.mModel.v.up, -gContext.mCameraDir };
+            const vec_t movePlanNormalAlt[] = { gContext.mModel.v.dir, gContext.mModel.v.right, gContext.mModel.v.up };
+            unsigned int planNormalIndex = type - MOVE_X;
+            vec_t movePlanNormalChosen = movePlanNormal[ planNormalIndex ];
+            if( planNormalIndex < 3 )
+            {
+                // single axis move, select best axis
+                vec_t movePlanNormalChosenAlt = movePlanNormalAlt[ planNormalIndex ];
+                float dotPlanNormal = fabsf( Dot( gContext.mCameraDir, movePlanNormalChosen ) );
+                float dotPlanNormalAlt = fabsf( Dot( gContext.mCameraDir, movePlanNormalChosenAlt ) );
+                if( dotPlanNormal < dotPlanNormalAlt )
+                {
+                    movePlanNormalChosen = movePlanNormalChosenAlt;
+                }
+            }
             // pickup plan
-            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - MOVE_X]);
+            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormalChosen );
             const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
             gContext.mTranslationPlanOrigin = gContext.mRayOrigin + gContext.mRayVector * len;
             gContext.mMatrixOrigin = gContext.mModel.v.position;

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1081,9 +1081,9 @@ namespace ImGuizmo
 				   bestAxisWorldDirection = dirPlaneNormalWorld;
 			   }
 
-			   if( dt >= 0.3f )
+			   if( dt >= 0.1f )
 			   {
-				   axes[numAxes] = bestAxis;
+				   axes[numAxes] = i;
 				   axesWorldDirections[numAxes] = dirPlaneNormalWorld;
 				   ++numAxes;
 			   }


### PR DESCRIPTION
This is on top of previous two changes, so commit to look at is actually the last one. Again I can pull this out or you can cherry pick the change.

Fixes the situation where the plane normal selected is perpendicular to the camera normal, so gizmo cannot be moved. This is due to there being two potential normal axis to a single movement axis, so the best of two choices must be selected.


