### PR TITLE
Added SetDrawlist() API 

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -660,6 +660,11 @@ namespace ImGuizmo
 	   gContext.mYMax = gContext.mY + gContext.mXMax;
    }
 
+   void SetDrawlist()
+   {
+      gContext.mDrawList = ImGui::GetWindowDrawList();
+   }
+
    void BeginFrame()
    {
       ImGuiIO& io = ImGui::GetIO();

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -112,6 +112,9 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 
 namespace ImGuizmo
 {
+	// call inside your own window and before Manipulate() in order to draw gizmo to that window.
+	IMGUI_API void SetDrawlist();
+
 	// call BeginFrame right after ImGui_XXXX_NewFrame();
 	IMGUI_API void BeginFrame();
 


### PR DESCRIPTION
Added SetDrawlist() API which, when called from within imgui window, allows rendering gizmo to that window.

This is useful for rendering gizmo inside a custom viewport which is contained within imgui window.