### PR TITLE
Fix MinGW warnings

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -765,8 +765,6 @@ namespace ImGuizmo
             for (int i = 0; i < 3; i++)
                colors[i + 1] = (type == (int)(SCALE_X + i)) ? selectionColor : directionColor[i];
             break;
-         case BOUNDS:
-             break;
          }
       }
       else

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -602,8 +602,6 @@ namespace ImGuizmo
 
    static ImVec2 worldToPos(const vec_t& worldPos, const matrix_t& mat)
    {
-      ImGuiIO& io = ImGui::GetIO();
-
       vec_t trans;
       trans.TransformPoint(worldPos, mat);
       trans *= 0.5f / trans.w;
@@ -864,7 +862,6 @@ namespace ImGuizmo
    static void DrawRotationGizmo(int type)
    {
       ImDrawList* drawList = gContext.mDrawList;
-      ImGuiIO& io = ImGui::GetIO();
 
       // colors
       ImU32 colors[7];


### PR DESCRIPTION
Fix warnings that occur when compiling with MinGW and `-Wall`.