### PR TITLE
clip rectangle not correct when slots out of parent window.

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -131,7 +131,7 @@ namespace ImSequencer
 			}
 
 			// clipping rect so items bars are not visible in the legend on the left when scrolled
-			draw_list->PushClipRect(ImVec2(canvas_pos.x + legendWidth, canvas_pos.y), ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + controlHeight));
+			draw_list->PushClipRect(ImVec2(canvas_pos.x + legendWidth, canvas_pos.y), ImVec2(canvas_pos.x + canvas_size.x, canvas_pos.y + controlHeight), true);
 			
 			// slots background
 			for (int i = 0; i < sequenceCount; i++)


### PR DESCRIPTION
![clip error](https://user-images.githubusercontent.com/4254953/40702943-3d06ce16-6416-11e8-890e-b59ed65767c5.png)
