### PR TITLE
Fix axis being swapped when interacting with gizmo.

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -877,8 +877,9 @@ namespace ImGuizmo
          belowAxisLimit = gContext.mBelowAxisLimit[axisIndex];
          belowPlaneLimit = gContext.mBelowPlaneLimit[axisIndex];
 
-         dirPlaneX *= gContext.mAxisFactor[axisIndex];
-         dirPlaneY *= gContext.mAxisFactor[(axisIndex + 1) % 3];
+         dirAxis *= gContext.mAxisFactor[axisIndex];
+         dirPlaneX *= gContext.mAxisFactor[(axisIndex + 1) % 3];
+         dirPlaneY *= gContext.mAxisFactor[(axisIndex + 2) % 3];
       }
       else
       {
@@ -908,7 +909,7 @@ namespace ImGuizmo
 
          // and store values
          gContext.mAxisFactor[axisIndex] = mulAxis;
-         gContext.mAxisFactor[(axisIndex + 1) % 3] = mulAxisY;
+         gContext.mAxisFactor[(axisIndex + 1) % 3] = mulAxisX;
          gContext.mAxisFactor[(axisIndex + 2) % 3] = mulAxisY;
          gContext.mBelowAxisLimit[axisIndex] = belowAxisLimit;
          gContext.mBelowPlaneLimit[axisIndex] = belowPlaneLimit;


### PR DESCRIPTION
⚠️ This PR requires careful review, please do not accept it blindly! ⚠️

Long story short: exact same code without changes in this PR would work correctly in one application, but in another application one axis would jump to opposite side upon interaction with gizmo. I tracked down issue to these variables and noticed mismatch between logic when gizmo is being used and when it isnt. Corrected cached values to be applied same way when gizmo is used and when it isnt. Everything appears to be working fine in my case, but truth is i have little idea what i did here so please carefully review my changes and make sure i did not break something being unaware of some non-obvious details.

Thanks!