### PR TITLE
Fix compilation on Linux  and support build without IMGUI_DEFINE_MATH_OPERATORS

### DIFF
--- a/ImCurveEdit.cpp
+++ b/ImCurveEdit.cpp
@@ -6,6 +6,25 @@
 
 namespace ImCurveEdit
 {
+   static ImVec2 operator+(const ImVec2 &a, const ImVec2 &b) {
+      return ImVec2(a.x + b.x, a.y + b.y);
+   }
+
+   static ImVec2 operator-(const ImVec2 &a, const ImVec2 &b) {
+      return ImVec2(a.x - b.x, a.y - b.y);
+   }
+
+   static ImVec2 operator*(const ImVec2 &a, const ImVec2 &b) {
+      return ImVec2(a.x * b.x, a.y * b.y);
+   }
+
+   static ImVec2 operator/(const ImVec2 &a, const ImVec2 &b) {
+      return ImVec2(a.x / b.x, a.y / b.y);
+   }
+
+   static ImVec2 operator*(const ImVec2 &a, const float b) {
+      return ImVec2(a.x * b, a.y * b);
+   }
 
    static float smoothstep(float edge0, float edge1, float x)
    {

--- a/ImGradient.cpp
+++ b/ImGradient.cpp
@@ -6,6 +6,14 @@
 
 namespace ImGradient
 {
+
+    static inline ImVec2 operator*(const ImVec2& lhs, const float rhs)              { return ImVec2(lhs.x*rhs, lhs.y*rhs); }
+    static inline ImVec2 operator/(const ImVec2& lhs, const float rhs)              { return ImVec2(lhs.x/rhs, lhs.y/rhs); }
+    static inline ImVec2 operator+(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x+rhs.x, lhs.y+rhs.y); }
+    static inline ImVec2 operator-(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x-rhs.x, lhs.y-rhs.y); }
+    static inline ImVec2 operator*(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x*rhs.x, lhs.y*rhs.y); }
+    static inline ImVec2 operator/(const ImVec2& lhs, const ImVec2& rhs)            { return ImVec2(lhs.x/rhs.x, lhs.y/rhs.y); }
+
    static int DrawPoint(ImDrawList* draw_list, ImVec4 color, const ImVec2 size, bool editing, ImVec2 pos)
    {
       int ret = 0;

--- a/ImGradient.h
+++ b/ImGradient.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <stdint.h>
+#include <cstddef>
 
 struct ImVec4;
 struct ImVec2;

--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -6,6 +6,10 @@
 namespace ImSequencer
 {
 
+  static ImVec2 operator+(const ImVec2 &a, const ImVec2 &b) {
+    return ImVec2(a.x + b.x, a.y + b.y);
+  }
+
 	static bool SequencerAddDelButton(ImDrawList* draw_list, ImVec2 pos, bool add = true)
 	{
 		ImGuiIO& io = ImGui::GetIO();

--- a/ImSequencer.h
+++ b/ImSequencer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 struct ImDrawList;
 struct ImRect;
 namespace ImSequencer


### PR DESCRIPTION
This PR fixes compilation error on Linux.
Also, make ImGuizmo compilable without defining `IMGUI_DEFINE_MATH_OPERATORS`
ImVec2 operators are disabled by default, so I have added operator overloading functions in appropriate place.