### PR TITLE
 Add parentheses to resolve operator precedence.

### DIFF
--- a/ImCurveEdit.cpp
+++ b/ImCurveEdit.cpp
@@ -281,7 +281,7 @@ namespace ImCurveEdit
       static std::vector<ImVec2> originalPoints;
       if (overSelectedPoint && io.MouseDown[0])
       {
-          if (fabsf(io.MouseDelta.x) > 0.f || fabsf(io.MouseDelta.y) > 0.f && !selection.empty())
+          if ((fabsf(io.MouseDelta.x) > 0.f || fabsf(io.MouseDelta.y) > 0.f) && !selection.empty())
           {
               if (!pointsMoved)
               {


### PR DESCRIPTION
clang compiler warns parentheses is required for the conditionals.

According to C++ operator precedence, https://en.cppreference.com/w/cpp/language/operator_precedence `&&` wins against `||`.
