### PR TITLE
Remove "C standard library is not secure" warnings form MSVC

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -1,3 +1,7 @@
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "ImSequencer.h"
 #include "imgui.h"
 #include "imgui_internal.h"


### PR DESCRIPTION
Microsoft's compiler want to bully you into using non-standard functions when building this program (or anything using functions like `sprintf`) with Visual Studio. There's a compile time setting that can silence thsese by `#define`-ing `_CRT_SECURE_NO_WARNINGS`.

This changes adopt the same stance as ImGui itself to locally define this just for our own compilation unit. As it's not in a header, it will not spill out to user's code