### PR TITLE
Fix clang warning about operator precedence in conditionals and potential selection move bug

### DIFF
--- a/ImCurveEdit.cpp
+++ b/ImCurveEdit.cpp
@@ -281,7 +281,7 @@ namespace ImCurveEdit
       static std::vector<ImVec2> originalPoints;
       if (overSelectedPoint && io.MouseDown[0])
       {
-          if (fabsf(io.MouseDelta.x) > 0.f || fabsf(io.MouseDelta.y) > 0.f && !selection.empty())
+          if ((fabsf(io.MouseDelta.x) > 0.f || fabsf(io.MouseDelta.y) > 0.f) && !selection.empty())
           {
               if (!pointsMoved)
               {


### PR DESCRIPTION
See https://travis-ci.org/lighttransport/gltf-insight/jobs/546072368#L1015

It also seems that the way it was written, it was doing the condition "absolute X > 0 **OR** (absolute Y > 0 **AND** selection not empty)

It seems that wee need to test (X > 0 OR Y > 0) **AND** "Selection is not empty". If that's the case, Clang found a bug in the logic. In *that* case, this PR fixes the real problem.