### PR TITLE
Add ImGui Viewport support.

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -824,8 +824,14 @@ namespace ImGuizmo
       ImGuiIO& io = ImGui::GetIO();
 
       const ImU32 flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus;
+      
+#ifdef IMGUI_HAS_VIEWPORT
+      ImGui::SetNextWindowSize(ImGui::GetMainViewport()->Size);
+	   ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos);
+#else
       ImGui::SetNextWindowSize(io.DisplaySize);
       ImGui::SetNextWindowPos(ImVec2(0, 0));
+#endif
 
       ImGui::PushStyleColor(ImGuiCol_WindowBg, 0);
       ImGui::PushStyleColor(ImGuiCol_Border, 0);

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -824,10 +824,10 @@ namespace ImGuizmo
       ImGuiIO& io = ImGui::GetIO();
 
       const ImU32 flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus;
-      
+    
 #ifdef IMGUI_HAS_VIEWPORT
       ImGui::SetNextWindowSize(ImGui::GetMainViewport()->Size);
-	   ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos);
+      ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos);
 #else
       ImGui::SetNextWindowSize(io.DisplaySize);
       ImGui::SetNextWindowPos(ImVec2(0, 0));


### PR DESCRIPTION
See https://github.com/CedricGuillemet/ImGuizmo/issues/78.
Basically offset the Guizmo window to fit the main viewport size and position.
This use the IMGUI_HAS_VIEWPORT defined in imgui.h in the docking branch.
Tested locally on my engine.
Close #78.