### PR TITLE
Added gizmo specific 'IsOver' function

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -881,6 +881,15 @@ namespace ImGuizmo
       return (GetMoveType(NULL) != NONE) || GetRotateType() != NONE || GetScaleType() != NONE || IsUsing();
    }
 
+   bool IsOver(OPERATION op) {
+      switch (op) {
+      case SCALE:       return GetScaleType()      != NONE || IsUsing();
+      case ROTATE:      return GetRotateType()     != NONE || IsUsing();
+      case TRANSLATE:   return GetMoveType(NULL)   != NONE || IsUsing();
+      }
+      return false;
+   }
+
    void Enable(bool enable)
    {
       gContext.mbEnable = enable;

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -179,4 +179,7 @@ namespace ImGuizmo
    IMGUI_API void ViewManipulate(float* view, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
    
    IMGUI_API void SetID(int id);
+   
+   // return true if the cursor is over the operation's gizmo
+   IMGUI_API bool IsOver(OPERATION op);
 };


### PR DESCRIPTION
I implemented object picking in my 3D project and had to make sure it only picks when my mouse is not hovering ImGuizmo but the current IsOver detects for all three gizmos even if they're not visible. This simple addition does it based on operation, since thats a client-side thing anyway.