### PR TITLE
dont define malloca if _WIN32 (_MSC_VER and mingw also), 0 -> NULL in…

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -26,7 +26,7 @@
 #endif
 #include "imgui_internal.h"
 #include "ImGuizmo.h"
-#if !defined(_MSC_VER)
+#if !defined(_WIN32) 
 #define _malloca(x) alloca(x)
 #endif
 #include <malloc.h>

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -170,7 +170,7 @@ namespace ImGuizmo
 		WORLD
 	};
 
-	IMGUI_API void Manipulate(const float *view, const float *projection, OPERATION operation, MODE mode, float *matrix, float *deltaMatrix = 0, float *snap = 0, float *localBounds = NULL, float *boundsSnap = NULL);
+	IMGUI_API void Manipulate(const float *view, const float *projection, OPERATION operation, MODE mode, float *matrix, float *deltaMatrix = NULL, float *snap = NULL, float *localBounds = NULL, float *boundsSnap = NULL);
    //
    // Please note that this cubeview is patented by Autodesk : https://patents.google.com/patent/US7782319B2/en
    // It seems to be a defensive patent in the US. I don't think it will bring troubles using it as


### PR DESCRIPTION
Hi,

I am using this for https://github.com/cimgui/cimguizmo to programatically generate C bindings for ImGuizmo
I made two changes in one commit (If that is not ok I could split them in two commits or two pull requests):

First change for avoiding _malloca redefinition in mingw-w64.
Second change for changing default argument for float* from 0 to NULL (the same as the other arguments and less ambiguous for the binding generator)

Thanks for your attention
 