### PR TITLE
ImGuizmo: added API support for rendering on any ImDrawList

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -844,9 +844,9 @@ namespace ImGuizmo
       gContext.mIsOrthographic = isOrthographic;
    }
 
-   void SetDrawlist()
+   void SetDrawlist(ImDrawList* drawlist)
    {
-      gContext.mDrawList = ImGui::GetWindowDrawList();
+      gContext.mDrawList = drawlist ? drawlist : ImGui::GetWindowDrawList();
 }
 
    void BeginFrame()

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -114,7 +114,6 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 namespace ImGuizmo
 {
 	// call inside your own window and before Manipulate() in order to draw gizmo to that window.
-	IMGUI_API void SetDrawlist();
 	// Or pass a specific ImDrawList to draw to (e.g. ImGui::GetForegroundDrawList()).
 	IMGUI_API void SetDrawlist(ImDrawList* drawlist = nullptr);
 

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -115,6 +115,8 @@ namespace ImGuizmo
 {
 	// call inside your own window and before Manipulate() in order to draw gizmo to that window.
 	IMGUI_API void SetDrawlist();
+	// Or pass a specific ImDrawList to draw to (e.g. ImGui::GetForegroundDrawList()).
+	IMGUI_API void SetDrawlist(ImDrawList* drawlist = nullptr);
 
 	// call BeginFrame right after ImGui_XXXX_NewFrame();
 	IMGUI_API void BeginFrame();


### PR DESCRIPTION
Added API support for rendering on any ImDrawList. This is useful to specify the target window without being in its `Begin() .. End()` block, and necessary to draw ImGuizmo to the overlay drawlist:
```
ImGuizmo::SetDrawlist(ImGui::GetForegroundDrawList());
```
