### PR TITLE
Include malloc.h only for Windows platforms.

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -28,8 +28,9 @@
 #include "ImGuizmo.h"
 #if !defined(_WIN32) 
 #define _malloca(x) alloca(x)
+#else
+#include <malloc.h>
 #endif
-#include <stdlib.h>
 
 // includes patches for multiview from
 // https://github.com/CedricGuillemet/ImGuizmo/issues/15


### PR DESCRIPTION
To fix the build issue omar mentioned.