### PR TITLE
Remove IMGUI_API on definition

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -841,7 +841,7 @@ namespace ImGuizmo
       gContext.mDisplayRatio = width / height;
    }
 
-   IMGUI_API void SetOrthographic(bool isOrthographic)
+   void SetOrthographic(bool isOrthographic)
    {
       gContext.mIsOrthographic = isOrthographic;
    }


### PR DESCRIPTION
Hi All!;

If `IMGUI_API` is set, Windows builds do not compile, as setting import attributes on definitions is invalid.

Best,
Jonathan