### PR TITLE
Fix ray intersection with rotation gizmo broken after #149 fix

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -957,8 +957,8 @@ namespace ImGuizmo
 
       // projection reverse
       vec_t near, far;
-      near.Transform(makeVect(0, 0, 1.f, 1.f), gContext.mProjectionMat);
-      far.Transform(makeVect(0, 0, 2.f, 1.f), gContext.mProjectionMat);
+      near.Transform(makeVect(0, 0, -1.f, 1.f), gContext.mProjectionMat);
+      far.Transform(makeVect(0, 0, -2.f, 1.f), gContext.mProjectionMat);
 
       gContext.mReversed = (near.z/near.w) > (far.z / far.w);
 


### PR DESCRIPTION
Hey @CedricGuillemet ,

the recent fix for #149 (well, specifically #144) actually introduced the buggy behavior in the example application. Now, raycast always picks the furthest part of rotation gizmo instead of the nearest one - just like it was shown in the #144. 

Please have a look at this PR for a fix. It fixes the example application, although I'm not quite sure that it work for different configuration convention of view/projection matrices.

Cheers,
Pavlo