### PR TITLE
Fix builds using -Werror -Wall

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -682,9 +682,6 @@ namespace ImGuizmo
 
    static Context gContext;
 
-   static const float angleLimit = 0.96f;
-   static const float planeLimit = 0.2f;
-
    static const vec_t directionUnary[3] = { makeVect(1.f, 0.f, 0.f), makeVect(0.f, 1.f, 0.f), makeVect(0.f, 0.f, 1.f) };
    static const ImU32 directionColor[3] = { 0xFF0000AA, 0xFF00AA00, 0xFFAA0000 };
 
@@ -863,8 +860,6 @@ namespace ImGuizmo
 
    void BeginFrame()
    {
-      ImGuiIO& io = ImGui::GetIO();
-
       const ImU32 flags = ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus;
 
 #ifdef IMGUI_HAS_VIEWPORT
@@ -903,6 +898,7 @@ namespace ImGuizmo
       case SCALE:       return GetScaleType() != NONE || IsUsing();
       case ROTATE:      return GetRotateType() != NONE || IsUsing();
       case TRANSLATE:   return GetMoveType(NULL) != NONE || IsUsing();
+      case BOUNDS: break;
       }
       return false;
    }
@@ -915,13 +911,6 @@ namespace ImGuizmo
          gContext.mbUsing = false;
          gContext.mbUsingBounds = false;
       }
-   }
-
-   static float GetUniform(const vec_t& position, const matrix_t& mat)
-   {
-      vec_t trf = makeVect(position.x, position.y, position.z, 1.f);
-      trf.Transform(mat);
-      return trf.w;
    }
 
    static void ComputeContext(const float* view, const float* projection, float* matrix, MODE mode)
@@ -1723,7 +1712,6 @@ namespace ImGuizmo
          const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, BuildPlan(gContext.mModel.v.position, dirAxis));
          vec_t posOnPlan = gContext.mRayOrigin + gContext.mRayVector * len;
 
-         const ImVec2 posOnPlanScreen = worldToPos(posOnPlan, gContext.mViewProjection);
          const ImVec2 axisStartOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor * 0.1f, gContext.mViewProjection);
          const ImVec2 axisEndOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor, gContext.mViewProjection);
 
@@ -2253,9 +2241,7 @@ namespace ImGuizmo
       {
          const float* matrix = &matrices[cube * 16];
 
-         const matrix_t& model = *(matrix_t*)matrix;
          matrix_t res = *(matrix_t*)matrix * *(matrix_t*)view * *(matrix_t*)projection;
-         matrix_t modelView = *(matrix_t*)matrix * *(matrix_t*)view;
 
          for (int iFace = 0; iFace < 6; iFace++)
          {
@@ -2456,10 +2442,6 @@ namespace ImGuizmo
             const vec_t indexVectorX = directionUnary[perpXIndex] * invert;
             const vec_t indexVectorY = directionUnary[perpYIndex] * invert;
             const vec_t boxOrigin = directionUnary[normalIndex] * -invert - indexVectorX - indexVectorY;
-            const vec_t faceCoords[4] = { directionUnary[normalIndex] + directionUnary[perpXIndex] + directionUnary[perpYIndex],
-                                          directionUnary[normalIndex] + directionUnary[perpXIndex] - directionUnary[perpYIndex],
-                                          directionUnary[normalIndex] - directionUnary[perpXIndex] - directionUnary[perpYIndex],
-                                          directionUnary[normalIndex] - directionUnary[perpXIndex] + directionUnary[perpYIndex] };
 
             // plan local space
             const vec_t n = directionUnary[normalIndex] * invert;
@@ -2617,4 +2599,3 @@ namespace ImGuizmo
       ComputeContext(svgView.m16, svgProjection.m16, gContext.mModelSource.m16, gContext.mMode);
    }
 };
-


### PR DESCRIPTION
Thanks for the nice library @CedricGuillemet . I tried to update to latest version and had a few errors reported for a build using more restrictive flags -Werror and -Wall, this is a small PR cleaning these errors (mainly unused variables). I'm only using ImGuizmo.cpp and ImGuizmo.h, so other files be affected.