### PR TITLE
Fix compile error

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -866,6 +866,7 @@ namespace ImGuizmo
       ImGui::SetNextWindowSize(ImGui::GetMainViewport()->Size);
       ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos);
 #else
+      ImGuiIO& io = ImGui::GetIO();
       ImGui::SetNextWindowSize(io.DisplaySize);
       ImGui::SetNextWindowPos(ImVec2(0, 0));
 #endif


### PR DESCRIPTION
Fixes compile errors which were introduced in the latest PR (ae1706f) due to the removal of

`ImGuiIO& io = ImGui::GetIO();`

inside BeginFrame, which was used for the next call to SetNextWindowSize.