### PR TITLE
Make OPERATION a bitmask and add AllowAxisFlip(bool)

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1293,9 +1293,11 @@ namespace ImGuizmo
          // draw axis
          if (belowAxisLimit)
          {
+            bool hasTranslateOnAxis = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i)) ;
+            float markerScale = hasTranslateOnAxis ? 1.4f : 1.0f;
             ImVec2 baseSSpace = worldToPos(dirAxis * 0.1f * gContext.mScreenFactor, gContext.mMVP);
-            ImVec2 worldDirSSpaceNoScale = worldToPos(dirAxis * gContext.mScreenFactor, gContext.mMVP);
-            ImVec2 worldDirSSpace = worldToPos((dirAxis * scaleDisplay[i]) * gContext.mScreenFactor, gContext.mMVP);
+            ImVec2 worldDirSSpaceNoScale = worldToPos(dirAxis * markerScale * gContext.mScreenFactor, gContext.mMVP);
+            ImVec2 worldDirSSpace = worldToPos((dirAxis * markerScale * scaleDisplay[i]) * gContext.mScreenFactor, gContext.mMVP);
 
             if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
             {
@@ -1303,7 +1305,10 @@ namespace ImGuizmo
                drawList->AddCircleFilled(worldDirSSpaceNoScale, 6.f, 0xFF404040);
             }
 
-            drawList->AddLine(baseSSpace, worldDirSSpace, colors[i + 1], 3.f);
+            if(!hasTranslateOnAxis || gContext.mbUsing)
+            {
+              drawList->AddLine(baseSSpace, worldDirSSpace, colors[i + 1], 3.f);
+            }
             drawList->AddCircleFilled(worldDirSSpace, 6.f, colors[i + 1]);
 
             if (gContext.mAxisFactor[i] < 0.f)
@@ -1727,9 +1732,11 @@ namespace ImGuizmo
          const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, BuildPlan(gContext.mModel.v.position, dirAxis));
          vec_t posOnPlan = gContext.mRayOrigin + gContext.mRayVector * len;
 
+         const float startOffset = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i)) ? 1.0f : 0.1f;
+         const float endOffset = Contains(op, static_cast<OPERATION>(TRANSLATE_X << i)) ? 1.4f : 1.0f;
          const ImVec2 posOnPlanScreen = worldToPos(posOnPlan, gContext.mViewProjection);
-         const ImVec2 axisStartOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor * 0.1f, gContext.mViewProjection);
-         const ImVec2 axisEndOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor, gContext.mViewProjection);
+         const ImVec2 axisStartOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor * startOffset, gContext.mViewProjection);
+         const ImVec2 axisEndOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor * endOffset, gContext.mViewProjection);
 
          vec_t closestPointOnAxis = PointOnSegment(makeVect(posOnPlanScreen), makeVect(axisStartOnScreen), makeVect(axisEndOnScreen));
 

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -26,7 +26,7 @@
 #endif
 #include "imgui_internal.h"
 #include "ImGuizmo.h"
-#if !defined(_WIN32) 
+#if !defined(_WIN32)
 #define _malloca(x) alloca(x)
 #else
 #include <malloc.h>
@@ -42,6 +42,32 @@ namespace ImGuizmo
    static const float DEG2RAD = (ZPI / 180.f);
    static float gGizmoSizeClipSpace = 0.1f;
    const float screenRotateSize = 0.06f;
+
+   static OPERATION operator&(OPERATION lhs, OPERATION rhs)
+   {
+     return static_cast<OPERATION>(static_cast<int>(lhs) & static_cast<int>(rhs));
+   }
+
+   static bool operator!=(OPERATION lhs, int rhs)
+   {
+     return static_cast<int>(lhs) != rhs;
+   }
+
+   static bool operator==(OPERATION lhs, int rhs)
+   {
+     return static_cast<int>(lhs) == rhs;
+   }
+
+   static bool Intersects(OPERATION lhs, OPERATION rhs)
+   {
+     return (lhs & rhs) != 0;
+   }
+
+   // True if lhs contains rhs
+   static bool Contains(OPERATION lhs, OPERATION rhs)
+   {
+     return (lhs & rhs) == rhs;
+   }
 
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    // utility and math
@@ -572,23 +598,41 @@ namespace ImGuizmo
 
    enum MOVETYPE
    {
-      NONE,
-      MOVE_X,
-      MOVE_Y,
-      MOVE_Z,
-      MOVE_YZ,
-      MOVE_ZX,
-      MOVE_XY,
-      MOVE_SCREEN,
-      ROTATE_X,
-      ROTATE_Y,
-      ROTATE_Z,
-      ROTATE_SCREEN,
-      SCALE_X,
-      SCALE_Y,
-      SCALE_Z,
-      SCALE_XYZ
+      MT_NONE,
+      MT_MOVE_X,
+      MT_MOVE_Y,
+      MT_MOVE_Z,
+      MT_MOVE_YZ,
+      MT_MOVE_ZX,
+      MT_MOVE_XY,
+      MT_MOVE_SCREEN,
+      MT_ROTATE_X,
+      MT_ROTATE_Y,
+      MT_ROTATE_Z,
+      MT_ROTATE_SCREEN,
+      MT_SCALE_X,
+      MT_SCALE_Y,
+      MT_SCALE_Z,
+      MT_SCALE_XYZ
    };
+
+   static bool IsTranslateType(int type)
+   {
+     return type >= MT_MOVE_X && type <= MT_MOVE_SCREEN;
+   }
+
+   static bool IsRotateType(int type)
+   {
+     return type >= MT_ROTATE_X && type <= MT_ROTATE_SCREEN;
+   }
+
+   static bool IsScaleType(int type)
+   {
+     return type >= MT_SCALE_X && type <= MT_SCALE_XYZ;
+   }
+
+   // Matches MT_MOVE_AB order
+   static const OPERATION TRANSLATE_PLANS[3] = { TRANSLATE_Y | TRANSLATE_Z, TRANSLATE_X | TRANSLATE_Z, TRANSLATE_X | TRANSLATE_Y };
 
    struct Context
    {
@@ -706,9 +750,9 @@ namespace ImGuizmo
 
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    //
-   static int GetMoveType(vec_t* gizmoHitProportion);
-   static int GetRotateType();
-   static int GetScaleType();
+   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion);
+   static int GetRotateType(OPERATION op);
+   static int GetScaleType(OPERATION op);
 
    static ImVec2 worldToPos(const vec_t& worldPos, const matrix_t& mat, ImVec2 position = ImVec2(gContext.mX, gContext.mY), ImVec2 size = ImVec2(gContext.mWidth, gContext.mHeight))
    {
@@ -855,7 +899,7 @@ namespace ImGuizmo
       gContext.mDrawList = drawlist ? drawlist : ImGui::GetWindowDrawList();
    }
 
-   void SetImGuiContext(ImGuiContext* ctx) 
+   void SetImGuiContext(ImGuiContext* ctx)
    {
       ImGui::SetCurrentContext(ctx);
    }
@@ -891,17 +935,28 @@ namespace ImGuizmo
 
    bool IsOver()
    {
-      return (gContext.mOperation == TRANSLATE && GetMoveType(NULL) != NONE) ||
-         (gContext.mOperation == ROTATE && GetRotateType() != NONE) ||
-         (gContext.mOperation == SCALE && GetScaleType() != NONE) || IsUsing();
+      return (Intersects(gContext.mOperation, TRANSLATE) && GetMoveType(gContext.mOperation, NULL) != MT_NONE) ||
+         (Intersects(gContext.mOperation, ROTATE) && GetRotateType(gContext.mOperation) != MT_NONE) ||
+         (Intersects(gContext.mOperation, SCALE) && GetScaleType(gContext.mOperation) != MT_NONE) || IsUsing();
    }
 
-   bool IsOver(OPERATION op) {
-      switch (op) {
-      case SCALE:       return gContext.mOperation == SCALE && GetScaleType() != NONE || IsUsing();
-      case ROTATE:      return gContext.mOperation == ROTATE && GetRotateType() != NONE || IsUsing();
-      case TRANSLATE:   return gContext.mOperation == TRANSLATE && GetMoveType(NULL) != NONE || IsUsing();
-      case BOUNDS: break;
+   bool IsOver(OPERATION op)
+   {
+      if(IsUsing())
+      {
+         return true;
+      }
+      if(Intersects(op, SCALE) && GetScaleType(op) != MT_NONE)
+      {
+         return true;
+      }
+      if(Intersects(op, ROTATE) && GetRotateType(op) != MT_NONE)
+      {
+         return true;
+      }
+      if(Intersects(op, TRANSLATE) && GetMoveType(op, NULL) != MT_NONE)
+      {
+         return true;
       }
       return false;
    }
@@ -952,7 +1007,7 @@ namespace ImGuizmo
       projectionInverse.Inverse(gContext.mViewProjection);
       far.Transform(makeVect(0, 0, 10.f, 1.f), projectionInverse);
       gContext.mReversed = (far.z/far.w) < 0.f;
-      
+
       // compute scale from the size of camera right vector projected on screen at the matrix position
       vec_t pointRight = viewInverse.v.right;
       pointRight.TransformPoint(gContext.mViewProjection);
@@ -978,29 +1033,30 @@ namespace ImGuizmo
          switch (operation)
          {
          case TRANSLATE:
-            colors[0] = (type == MOVE_SCREEN) ? selectionColor : 0xFFFFFFFF;
+            colors[0] = (type == MT_MOVE_SCREEN) ? selectionColor : 0xFFFFFFFF;
             for (int i = 0; i < 3; i++)
             {
-               colors[i + 1] = (type == (int)(MOVE_X + i)) ? selectionColor : directionColor[i];
-               colors[i + 4] = (type == (int)(MOVE_YZ + i)) ? selectionColor : planeColor[i];
-               colors[i + 4] = (type == MOVE_SCREEN) ? selectionColor : colors[i + 4];
+               colors[i + 1] = (type == (int)(MT_MOVE_X + i)) ? selectionColor : directionColor[i];
+               colors[i + 4] = (type == (int)(MT_MOVE_YZ + i)) ? selectionColor : planeColor[i];
+               colors[i + 4] = (type == MT_MOVE_SCREEN) ? selectionColor : colors[i + 4];
             }
             break;
          case ROTATE:
-            colors[0] = (type == ROTATE_SCREEN) ? selectionColor : 0xFFFFFFFF;
+            colors[0] = (type == MT_ROTATE_SCREEN) ? selectionColor : 0xFFFFFFFF;
             for (int i = 0; i < 3; i++)
             {
-               colors[i + 1] = (type == (int)(ROTATE_X + i)) ? selectionColor : directionColor[i];
+               colors[i + 1] = (type == (int)(MT_ROTATE_X + i)) ? selectionColor : directionColor[i];
             }
             break;
          case SCALE:
-            colors[0] = (type == SCALE_XYZ) ? selectionColor : 0xFFFFFFFF;
+            colors[0] = (type == MT_SCALE_XYZ) ? selectionColor : 0xFFFFFFFF;
             for (int i = 0; i < 3; i++)
             {
-               colors[i + 1] = (type == (int)(SCALE_X + i)) ? selectionColor : directionColor[i];
+               colors[i + 1] = (type == (int)(MT_SCALE_X + i)) ? selectionColor : directionColor[i];
             }
             break;
-         case BOUNDS:
+         // note: this internal function is only called with three possible values for operation
+         default:
             break;
          }
       }
@@ -1106,8 +1162,12 @@ namespace ImGuizmo
       return angle;
    }
 
-   static void DrawRotationGizmo(int type)
+   static void DrawRotationGizmo(OPERATION op, int type)
    {
+      if(!Intersects(op, ROTATE))
+      {
+         return;
+      }
       ImDrawList* drawList = gContext.mDrawList;
 
       // colors
@@ -1130,15 +1190,21 @@ namespace ImGuizmo
 
       gContext.mRadiusSquareCenter = screenRotateSize * gContext.mHeight;
 
+      bool hasRSC = Intersects(op, ROTATE_SCREEN);
+      int circleMul = hasRSC ? 1 : 2;
       for (int axis = 0; axis < 3; axis++)
       {
-         ImVec2 circlePos[halfCircleSegmentCount];
+         if(!Intersects(op, static_cast<OPERATION>(ROTATE_Z >> axis)))
+         {
+            continue;
+         }
+         ImVec2 circlePos[circleMul * halfCircleSegmentCount + 1];
 
          float angleStart = atan2f(cameraToModelNormalized[(4 - axis) % 3], cameraToModelNormalized[(3 - axis) % 3]) + ZPI * 0.5f;
 
-         for (unsigned int i = 0; i < halfCircleSegmentCount; i++)
+         for (unsigned int i = 0; i < circleMul * halfCircleSegmentCount + 1; i++)
          {
-            float ng = angleStart + ZPI * ((float)i / (float)halfCircleSegmentCount);
+            float ng = angleStart + circleMul * ZPI * ((float)i / (float)halfCircleSegmentCount);
             vec_t axisPos = makeVect(cosf(ng), sinf(ng), 0.f);
             vec_t pos = makeVect(axisPos[axis], axisPos[(axis + 1) % 3], axisPos[(axis + 2) % 3]) * gContext.mScreenFactor;
             circlePos[i] = worldToPos(pos, gContext.mMVP);
@@ -1150,11 +1216,14 @@ namespace ImGuizmo
             gContext.mRadiusSquareCenter = radiusAxis;
          }
 
-         drawList->AddPolyline(circlePos, halfCircleSegmentCount, colors[3 - axis], false, 2);
+         drawList->AddPolyline(circlePos, circleMul * halfCircleSegmentCount + 1, colors[3 - axis], false, 2);
       }
-      drawList->AddCircle(worldToPos(gContext.mModel.v.position, gContext.mViewProjection), gContext.mRadiusSquareCenter, colors[0], 64, 3.f);
+      if(hasRSC)
+      {
+         drawList->AddCircle(worldToPos(gContext.mModel.v.position, gContext.mViewProjection), gContext.mRadiusSquareCenter, colors[0], 64, 3.f);
+      }
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(type))
       {
          ImVec2 circlePos[halfCircleSegmentCount + 1];
 
@@ -1174,7 +1243,7 @@ namespace ImGuizmo
 
          ImVec2 destinationPosOnScreen = circlePos[1];
          char tmps[512];
-         ImFormatString(tmps, sizeof(tmps), rotationInfoMask[type - ROTATE_X], (gContext.mRotationAngle / ZPI) * 180.f, gContext.mRotationAngle);
+         ImFormatString(tmps, sizeof(tmps), rotationInfoMask[type - MT_ROTATE_X], (gContext.mRotationAngle / ZPI) * 180.f, gContext.mRotationAngle);
          drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), 0xFF000000, tmps);
          drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), 0xFFFFFFFF, tmps);
       }
@@ -1190,9 +1259,14 @@ namespace ImGuizmo
       }
    }
 
-   static void DrawScaleGizmo(int type)
+   static void DrawScaleGizmo(OPERATION op, int type)
    {
       ImDrawList* drawList = gContext.mDrawList;
+
+      if(!Intersects(op, SCALE))
+      {
+        return;
+      }
 
       // colors
       ImU32 colors[7];
@@ -1208,6 +1282,10 @@ namespace ImGuizmo
 
       for (unsigned int i = 0; i < 3; i++)
       {
+         if(!Intersects(op, static_cast<OPERATION>(SCALE_X << i)))
+         {
+            continue;
+         }
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
          ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
@@ -1238,7 +1316,7 @@ namespace ImGuizmo
       // draw screen cirle
       drawList->AddCircleFilled(gContext.mScreenSquareCenter, 6.f, colors[0], 32);
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(type))
       {
          //ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
          ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
@@ -1251,18 +1329,23 @@ namespace ImGuizmo
          */
          char tmps[512];
          //vec_t deltaInfo = gContext.mModel.v.position - gContext.mMatrixOrigin;
-         int componentInfoIndex = (type - SCALE_X) * 3;
-         ImFormatString(tmps, sizeof(tmps), scaleInfoMask[type - SCALE_X], scaleDisplay[translationInfoIndex[componentInfoIndex]]);
+         int componentInfoIndex = (type - MT_SCALE_X) * 3;
+         ImFormatString(tmps, sizeof(tmps), scaleInfoMask[type - MT_SCALE_X], scaleDisplay[translationInfoIndex[componentInfoIndex]]);
          drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), 0xFF000000, tmps);
          drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), 0xFFFFFFFF, tmps);
       }
    }
 
 
-   static void DrawTranslationGizmo(int type)
+   static void DrawTranslationGizmo(OPERATION op, int type)
    {
       ImDrawList* drawList = gContext.mDrawList;
       if (!drawList)
+      {
+         return;
+      }
+
+      if(!Intersects(op, TRANSLATE))
       {
          return;
       }
@@ -1282,7 +1365,7 @@ namespace ImGuizmo
          ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
 
          // draw axis
-         if (belowAxisLimit)
+         if (belowAxisLimit && Intersects(op, static_cast<OPERATION>(TRANSLATE_X << i)))
          {
             ImVec2 baseSSpace = worldToPos(dirAxis * 0.1f * gContext.mScreenFactor, gContext.mMVP);
             ImVec2 worldDirSSpace = worldToPos(dirAxis * gContext.mScreenFactor, gContext.mMVP);
@@ -1308,7 +1391,7 @@ namespace ImGuizmo
          }
 
          // draw plane
-         if (belowPlaneLimit)
+         if (belowPlaneLimit && Contains(op, TRANSLATE_PLANS[i]))
          {
             ImVec2 screenQuadPts[4];
             for (int j = 0; j < 4; ++j)
@@ -1323,7 +1406,7 @@ namespace ImGuizmo
 
       drawList->AddCircleFilled(gContext.mScreenSquareCenter, 6.f, colors[0], 32);
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(type))
       {
          ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
          ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
@@ -1336,8 +1419,8 @@ namespace ImGuizmo
 
          char tmps[512];
          vec_t deltaInfo = gContext.mModel.v.position - gContext.mMatrixOrigin;
-         int componentInfoIndex = (type - MOVE_X) * 3;
-         ImFormatString(tmps, sizeof(tmps), translationInfoMask[type - MOVE_X], deltaInfo[translationInfoIndex[componentInfoIndex]], deltaInfo[translationInfoIndex[componentInfoIndex + 1]], deltaInfo[translationInfoIndex[componentInfoIndex + 2]]);
+         int componentInfoIndex = (type - MT_MOVE_X) * 3;
+         ImFormatString(tmps, sizeof(tmps), translationInfoMask[type - MT_MOVE_X], deltaInfo[translationInfoIndex[componentInfoIndex]], deltaInfo[translationInfoIndex[componentInfoIndex + 1]], deltaInfo[translationInfoIndex[componentInfoIndex + 2]]);
          drawList->AddText(ImVec2(destinationPosOnScreen.x + 15, destinationPosOnScreen.y + 15), 0xFF000000, tmps);
          drawList->AddText(ImVec2(destinationPosOnScreen.x + 14, destinationPosOnScreen.y + 14), 0xFFFFFFFF, tmps);
       }
@@ -1467,17 +1550,23 @@ namespace ImGuizmo
             bool overBigAnchor = ImLengthSqr(worldBound1 - io.MousePos) <= (AnchorBigRadius * AnchorBigRadius);
             bool overSmallAnchor = ImLengthSqr(midBound - io.MousePos) <= (AnchorBigRadius * AnchorBigRadius);
 
-            int type = NONE;
+            int type = MT_NONE;
             vec_t gizmoHitProportion;
 
-            switch (operation)
+            if(Intersects(operation, TRANSLATE))
             {
-            case TRANSLATE: type = GetMoveType(&gizmoHitProportion); break;
-            case ROTATE: type = GetRotateType(); break;
-            case SCALE: type = GetScaleType(); break;
-            case BOUNDS: break;
+               type = GetMoveType(operation, &gizmoHitProportion);
             }
-            if (type != NONE)
+            if(Intersects(operation, ROTATE) && type == MT_NONE)
+            {
+               type = GetRotateType(operation);
+            }
+            if(Intersects(operation, SCALE) && type == MT_NONE)
+            {
+               type = GetScaleType(operation);
+            }
+
+            if (type != MT_NONE)
             {
                overBigAnchor = false;
                overSmallAnchor = false;
@@ -1608,21 +1697,26 @@ namespace ImGuizmo
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    //
 
-   static int GetScaleType()
+   static int GetScaleType(OPERATION op)
    {
       ImGuiIO& io = ImGui::GetIO();
-      int type = NONE;
+      int type = MT_NONE;
 
       // screen
       if (io.MousePos.x >= gContext.mScreenSquareMin.x && io.MousePos.x <= gContext.mScreenSquareMax.x &&
-         io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y)
+         io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y &&
+         Contains(op, SCALE))
       {
-         type = SCALE_XYZ;
+         type = MT_SCALE_XYZ;
       }
 
       // compute
-      for (unsigned int i = 0; i < 3 && type == NONE; i++)
+      for (unsigned int i = 0; i < 3 && type == MT_NONE; i++)
       {
+         if(!Intersects(op, static_cast<OPERATION>(SCALE_X << i)))
+         {
+            continue;
+         }
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
          ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
@@ -1641,28 +1735,32 @@ namespace ImGuizmo
 
          if ((closestPointOnAxis - makeVect(posOnPlanScreen)).Length() < 12.f) // pixel size
          {
-            type = SCALE_X + i;
+            type = MT_SCALE_X + i;
          }
       }
       return type;
    }
 
-   static int GetRotateType()
+   static int GetRotateType(OPERATION op)
    {
       ImGuiIO& io = ImGui::GetIO();
-      int type = NONE;
+      int type = MT_NONE;
 
       vec_t deltaScreen = { io.MousePos.x - gContext.mScreenSquareCenter.x, io.MousePos.y - gContext.mScreenSquareCenter.y, 0.f, 0.f };
       float dist = deltaScreen.Length();
-      if (dist >= (gContext.mRadiusSquareCenter - 1.0f) && dist < (gContext.mRadiusSquareCenter + 1.0f))
+      if (Intersects(op, ROTATE_SCREEN) && dist >= (gContext.mRadiusSquareCenter - 1.0f) && dist < (gContext.mRadiusSquareCenter + 1.0f))
       {
-         type = ROTATE_SCREEN;
+         type = MT_ROTATE_SCREEN;
       }
 
       const vec_t planNormals[] = { gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir };
 
-      for (unsigned int i = 0; i < 3 && type == NONE; i++)
+      for (unsigned int i = 0; i < 3 && type == MT_NONE; i++)
       {
+         if(!Intersects(op, static_cast<OPERATION>(ROTATE_X << i)))
+         {
+            continue;
+         }
          // pickup plan
          vec_t pickupPlan = BuildPlan(gContext.mModel.v.position, planNormals[i]);
 
@@ -1683,29 +1781,34 @@ namespace ImGuizmo
          float distance = makeVect(distanceOnScreen).Length();
          if (distance < 8.f) // pixel size
          {
-            type = ROTATE_X + i;
+            type = MT_ROTATE_X + i;
          }
       }
 
       return type;
    }
 
-   static int GetMoveType(vec_t* gizmoHitProportion)
+   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion)
    {
+      if(!Intersects(op, TRANSLATE))
+      {
+        return MT_NONE;
+      }
       ImGuiIO& io = ImGui::GetIO();
-      int type = NONE;
+      int type = MT_NONE;
 
       // screen
       if (io.MousePos.x >= gContext.mScreenSquareMin.x && io.MousePos.x <= gContext.mScreenSquareMax.x &&
-         io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y)
+         io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y &&
+         Contains(op, TRANSLATE))
       {
-         type = MOVE_SCREEN;
+         type = MT_MOVE_SCREEN;
       }
 
       const vec_t screenCoord = makeVect(io.MousePos - ImVec2(gContext.mX, gContext.mY));
 
       // compute
-      for (unsigned int i = 0; i < 3 && type == NONE; i++)
+      for (unsigned int i = 0; i < 3 && type == MT_NONE; i++)
       {
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
@@ -1721,16 +1824,16 @@ namespace ImGuizmo
          const ImVec2 axisEndOnScreen = worldToPos(gContext.mModel.v.position + dirAxis * gContext.mScreenFactor, gContext.mViewProjection) - ImVec2(gContext.mX, gContext.mY);
 
          vec_t closestPointOnAxis = PointOnSegment(screenCoord, makeVect(axisStartOnScreen), makeVect(axisEndOnScreen));
-         if ((closestPointOnAxis - screenCoord).Length() < 12.f) // pixel size
+         if ((closestPointOnAxis - screenCoord).Length() < 12.f && Intersects(op, static_cast<OPERATION>(TRANSLATE_X << i))) // pixel size
          {
-            type = MOVE_X + i;
+            type = MT_MOVE_X + i;
          }
 
          const float dx = dirPlaneX.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
          const float dy = dirPlaneY.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
-         if (belowPlaneLimit && dx >= quadUV[0] && dx <= quadUV[4] && dy >= quadUV[1] && dy <= quadUV[3])
+         if (belowPlaneLimit && dx >= quadUV[0] && dx <= quadUV[4] && dy >= quadUV[1] && dy <= quadUV[3] && Contains(op, TRANSLATE_PLANS[i]))
          {
-            type = MOVE_YZ + i;
+            type = MT_MOVE_YZ + i;
          }
 
          if (gizmoHitProportion)
@@ -1741,14 +1844,18 @@ namespace ImGuizmo
       return type;
    }
 
-   static bool HandleTranslation(float* matrix, float* deltaMatrix, int& type, const float* snap)
+   static bool HandleTranslation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
    {
+      if(!Intersects(op, TRANSLATE) || type != MT_NONE)
+      {
+        return false;
+      }
       ImGuiIO& io = ImGui::GetIO();
-      bool applyRotationLocaly = gContext.mMode == LOCAL || type == MOVE_SCREEN;
+      bool applyRotationLocaly = gContext.mMode == LOCAL || type == MT_MOVE_SCREEN;
       bool modified = false;
 
       // move
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(gContext.mCurrentOperation))
       {
          ImGui::CaptureMouseFromApp();
          const float len = fabsf(IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan)); // near plan
@@ -1759,9 +1866,9 @@ namespace ImGuizmo
          vec_t delta = newOrigin - gContext.mModel.v.position;
 
          // 1 axis constraint
-         if (gContext.mCurrentOperation >= MOVE_X && gContext.mCurrentOperation <= MOVE_Z)
+         if (gContext.mCurrentOperation >= MT_MOVE_X && gContext.mCurrentOperation <= MT_MOVE_Z)
          {
-            int axisIndex = gContext.mCurrentOperation - MOVE_X;
+            int axisIndex = gContext.mCurrentOperation - MT_MOVE_X;
             const vec_t& axisValue = *(vec_t*)&gContext.mModel.m[axisIndex];
             float lengthOnAxis = Dot(axisValue, delta);
             delta = axisValue * lengthOnAxis;
@@ -1817,12 +1924,12 @@ namespace ImGuizmo
       {
          // find new possible way to move
          vec_t gizmoHitProportion;
-         type = GetMoveType(&gizmoHitProportion);
-         if (type != NONE)
+         type = GetMoveType(op, &gizmoHitProportion);
+         if (type != MT_NONE)
          {
             ImGui::CaptureMouseFromApp();
          }
-         if (CanActivate() && type != NONE)
+         if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
             gContext.mEditingID = gContext.mActualID;
@@ -1839,7 +1946,7 @@ namespace ImGuizmo
                movePlanNormal[i].Normalize();
             }
             // pickup plan
-            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - MOVE_X]);
+            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - MT_MOVE_X]);
             const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
             gContext.mTranslationPlanOrigin = gContext.mRayOrigin + gContext.mRayVector * len;
             gContext.mMatrixOrigin = gContext.mModel.v.position;
@@ -1850,20 +1957,24 @@ namespace ImGuizmo
       return modified;
    }
 
-   static bool HandleScale(float* matrix, float* deltaMatrix, int& type, const float* snap)
+   static bool HandleScale(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
    {
+      if(!Intersects(op, SCALE) || type != MT_NONE)
+      {
+         return false;
+      }
       ImGuiIO& io = ImGui::GetIO();
       bool modified = false;
 
       if (!gContext.mbUsing)
       {
          // find new possible way to scale
-         type = GetScaleType();
-         if (type != NONE)
+         type = GetScaleType(op);
+         if (type != MT_NONE)
          {
             ImGui::CaptureMouseFromApp();
          }
-         if (CanActivate() && type != NONE)
+         if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
             gContext.mEditingID = gContext.mActualID;
@@ -1871,7 +1982,7 @@ namespace ImGuizmo
             const vec_t movePlanNormal[] = { gContext.mModel.v.up, gContext.mModel.v.dir, gContext.mModel.v.right, gContext.mModel.v.dir, gContext.mModel.v.up, gContext.mModel.v.right, -gContext.mCameraDir };
             // pickup plan
 
-            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - SCALE_X]);
+            gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, movePlanNormal[type - MT_SCALE_X]);
             const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
             gContext.mTranslationPlanOrigin = gContext.mRayOrigin + gContext.mRayVector * len;
             gContext.mMatrixOrigin = gContext.mModel.v.position;
@@ -1882,7 +1993,7 @@ namespace ImGuizmo
          }
       }
       // scale
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(gContext.mCurrentOperation))
       {
          ImGui::CaptureMouseFromApp();
          const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
@@ -1891,9 +2002,9 @@ namespace ImGuizmo
          vec_t delta = newOrigin - gContext.mModel.v.position;
 
          // 1 axis constraint
-         if (gContext.mCurrentOperation >= SCALE_X && gContext.mCurrentOperation <= SCALE_Z)
+         if (gContext.mCurrentOperation >= MT_SCALE_X && gContext.mCurrentOperation <= MT_SCALE_Z)
          {
-            int axisIndex = gContext.mCurrentOperation - SCALE_X;
+            int axisIndex = gContext.mCurrentOperation - MT_SCALE_X;
             const vec_t& axisValue = *(vec_t*)&gContext.mModel.m[axisIndex];
             float lengthOnAxis = Dot(axisValue, delta);
             delta = axisValue * lengthOnAxis;
@@ -1956,27 +2067,31 @@ namespace ImGuizmo
       return modified;
    }
 
-   static bool HandleRotation(float* matrix, float* deltaMatrix, int& type, const float* snap)
+   static bool HandleRotation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
    {
+      if(!Intersects(op, ROTATE) || type != MT_NONE)
+      {
+        return false;
+      }
       ImGuiIO& io = ImGui::GetIO();
       bool applyRotationLocaly = gContext.mMode == LOCAL;
       bool modified = false;
 
       if (!gContext.mbUsing)
       {
-         type = GetRotateType();
+         type = GetRotateType(op);
 
-         if (type != NONE)
+         if (type != MT_NONE)
          {
             ImGui::CaptureMouseFromApp();
          }
 
-         if (type == ROTATE_SCREEN)
+         if (type == MT_ROTATE_SCREEN)
          {
             applyRotationLocaly = true;
          }
 
-         if (CanActivate() && type != NONE)
+         if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
             gContext.mEditingID = gContext.mActualID;
@@ -1985,11 +2100,11 @@ namespace ImGuizmo
             // pickup plan
             if (applyRotationLocaly)
             {
-               gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, rotatePlanNormal[type - ROTATE_X]);
+               gContext.mTranslationPlan = BuildPlan(gContext.mModel.v.position, rotatePlanNormal[type - MT_ROTATE_X]);
             }
             else
             {
-               gContext.mTranslationPlan = BuildPlan(gContext.mModelSource.v.position, directionUnary[type - ROTATE_X]);
+               gContext.mTranslationPlan = BuildPlan(gContext.mModelSource.v.position, directionUnary[type - MT_ROTATE_X]);
             }
 
             const float len = IntersectRayPlane(gContext.mRayOrigin, gContext.mRayVector, gContext.mTranslationPlan);
@@ -2000,7 +2115,7 @@ namespace ImGuizmo
       }
 
       // rotation
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(gContext.mCurrentOperation))
       {
          ImGui::CaptureMouseFromApp();
          gContext.mRotationAngle = ComputeAngleOnPlan();
@@ -2131,26 +2246,15 @@ namespace ImGuizmo
       }
 
       // --
-      int type = NONE;
+      int type = MT_NONE;
       bool manipulated = false;
       if (gContext.mbEnable)
       {
          if (!gContext.mbUsingBounds)
          {
-            switch (operation)
-            {
-            case ROTATE:
-               manipulated = HandleRotation(matrix, deltaMatrix, type, snap);
-               break;
-            case TRANSLATE:
-               manipulated = HandleTranslation(matrix, deltaMatrix, type, snap);
-               break;
-            case SCALE:
-               manipulated = HandleScale(matrix, deltaMatrix, type, snap);
-               break;
-            case BOUNDS:
-               break;
-            }
+            manipulated = HandleTranslation(matrix, deltaMatrix, operation, type, snap) ||
+                          HandleRotation(matrix, deltaMatrix, operation, type, snap) ||
+                          HandleScale(matrix, deltaMatrix, operation, type, snap);
          }
       }
 
@@ -2162,20 +2266,9 @@ namespace ImGuizmo
       gContext.mOperation = operation;
       if (!gContext.mbUsingBounds)
       {
-         switch (operation)
-         {
-         case ROTATE:
-            DrawRotationGizmo(type);
-            break;
-         case TRANSLATE:
-            DrawTranslationGizmo(type);
-            break;
-         case SCALE:
-            DrawScaleGizmo(type);
-            break;
-         case BOUNDS:
-            break;
-         }
+         DrawRotationGizmo(operation, type);
+         DrawTranslationGizmo(operation, type);
+         DrawScaleGizmo(operation, type);
       }
       return manipulated;
    }

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2263,8 +2263,8 @@ namespace ImGuizmo
          if (!gContext.mbUsingBounds)
          {
             manipulated = HandleTranslation(matrix, deltaMatrix, operation, type, snap) ||
-                          HandleRotation(matrix, deltaMatrix, operation, type, snap) ||
-                          HandleScale(matrix, deltaMatrix, operation, type, snap);
+                          HandleScale(matrix, deltaMatrix, operation, type, snap) ||
+                          HandleRotation(matrix, deltaMatrix, operation, type, snap);
          }
       }
 

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2060,7 +2060,10 @@ namespace ImGuizmo
          }
 
          if (!io.MouseDown[0])
+         {
             gContext.mbUsing = false;
+            gContext.mScale.Set(1.f, 1.f, 1.f);
+         }
 
          type = gContext.mCurrentOperation;
       }

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -678,6 +678,8 @@ namespace ImGuizmo
       int mActualID = -1;
       int mEditingID = -1;
       OPERATION mOperation = OPERATION(-1);
+
+      bool mAllowAxisFlip = true;
    };
 
    static Context gContext;
@@ -1039,9 +1041,11 @@ namespace ImGuizmo
          float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY);
          float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY);
 
-         float mulAxis = (lenDir < lenDirMinus&& fabsf(lenDir - lenDirMinus) > FLT_EPSILON) ? -1.f : 1.f;
-         float mulAxisX = (lenDirPlaneX < lenDirMinusPlaneX&& fabsf(lenDirPlaneX - lenDirMinusPlaneX) > FLT_EPSILON) ? -1.f : 1.f;
-         float mulAxisY = (lenDirPlaneY < lenDirMinusPlaneY&& fabsf(lenDirPlaneY - lenDirMinusPlaneY) > FLT_EPSILON) ? -1.f : 1.f;
+         // For readability
+         bool & allowFlip = gContext.mAllowAxisFlip;
+         float mulAxis = (allowFlip && lenDir < lenDirMinus&& fabsf(lenDir - lenDirMinus) > FLT_EPSILON) ? -1.f : 1.f;
+         float mulAxisX = (allowFlip && lenDirPlaneX < lenDirMinusPlaneX&& fabsf(lenDirPlaneX - lenDirMinusPlaneX) > FLT_EPSILON) ? -1.f : 1.f;
+         float mulAxisY = (allowFlip && lenDirPlaneY < lenDirMinusPlaneY&& fabsf(lenDirPlaneY - lenDirMinusPlaneY) > FLT_EPSILON) ? -1.f : 1.f;
          dirAxis *= mulAxis;
          dirPlaneX *= mulAxisX;
          dirPlaneY *= mulAxisY;
@@ -2101,6 +2105,11 @@ namespace ImGuizmo
    void SetID(int id)
    {
       gContext.mActualID = id;
+   }
+
+   void AllowAxisFlip(bool value)
+   {
+     gContext.mAllowAxisFlip = value;
    }
 
    bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix, const float* snap, const float* localBounds, const float* boundsSnap)

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -190,4 +190,9 @@ namespace ImGuizmo
    // return true if the cursor is over the operation's gizmo
    IMGUI_API bool IsOver(OPERATION op);
    IMGUI_API void SetGizmoSizeClipSpace(float value);
-};
+
+   // Allow axis to flip
+   // When true (default), the guizmo axis flip for better visibility
+   // When false, they always stay along the positive world/local axis
+   IMGUI_API void AllowAxisFlip(bool value);
+}

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -165,11 +165,26 @@ namespace ImGuizmo
    // translation is applied in world space
    enum OPERATION
    {
-      TRANSLATE,
-      ROTATE,
-      SCALE,
-      BOUNDS,
+      TRANSLATE_X      = (1u << 0),
+      TRANSLATE_Y      = (1u << 1),
+      TRANSLATE_Z      = (1u << 2),
+      ROTATE_X         = (1u << 3),
+      ROTATE_Y         = (1u << 4),
+      ROTATE_Z         = (1u << 5),
+      ROTATE_SCREEN    = (1u << 6),
+      SCALE_X          = (1u << 7),
+      SCALE_Y          = (1u << 8),
+      SCALE_Z          = (1u << 9),
+      BOUNDS           = (1u << 10),
+      TRANSLATE = TRANSLATE_X | TRANSLATE_Y | TRANSLATE_Z,
+      ROTATE = ROTATE_X | ROTATE_Y | ROTATE_Z | ROTATE_SCREEN,
+      SCALE = SCALE_X | SCALE_Y | SCALE_Z
    };
+
+   inline OPERATION operator|(OPERATION lhs, OPERATION rhs)
+   {
+     return static_cast<OPERATION>(static_cast<int>(lhs) | static_cast<int>(rhs));
+   }
 
    enum MODE
    {


### PR DESCRIPTION
Hello and thanks for the great work on this library.

I implemented OPERATION as a bitmask which in turns allow to select specific axes and to mix different operation modes (see #141 #85)

Some notes:
- `TRANSLATE`, `ROTATE`, `SCALE` and `BOUNDS` still exist (but the values have changed) I think it will not break any existing code for users of this library
- when an axis has a translation and scaling control widget (e.g. `TRANSLATE_X | SCALE_X`) I've removed the shaft from the scale control and pushed the sphere so that it appears a little detached from the translation axis
- translation has priority over scaling and scaling has priority over rotation, I found this gives a more intuitive UI

I have also introduced the `AllowAxisFlip(bool)` function which allows to disable the direction change that happens when one axis is not visible enough in the current view (i.e. this allows to lock the axis to the positive direction of the world/local frame). I am not super convinced by the name but I couldn't think of a better one.
