### PR TITLE
Added EnableViewManipulate and IsOverViewManipulate.

### DIFF
--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -193,12 +193,17 @@ namespace ImGuizmo
    };
 
    IMGUI_API bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix = NULL, const float* snap = NULL, const float* localBounds = NULL, const float* boundsSnap = NULL);
+
+   IMGUI_API void EnableViewManipulate(bool enable);
+   IMGUI_API bool IsOverViewManipulate();
+
    //
    // Please note that this cubeview is patented by Autodesk : https://patents.google.com/patent/US7782319B2/en
    // It seems to be a defensive patent in the US. I don't think it will bring troubles using it as
    // other software are using the same mechanics. But just in case, you are now warned!
    //
    IMGUI_API void ViewManipulate(float* view, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
+
 
    IMGUI_API void SetID(int id);
 


### PR DESCRIPTION
The action of enabling/disabling the ViewManipulate gizmo doesn't change its color the way disabling other gizmos do, can be easily added.

IsOverViewManipulate considers the background transparency to check if its over. Fully transparent backgrounds do not change the state.

Also changed the drag logic a little so that the interaction only starts when you click & drag inside the interaction area and not anywhere on screen and then drag on top of the gizmo.