### PR TITLE
Clip bounds only when both bound ends are not visible.

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1531,7 +1531,7 @@ namespace ImGuizmo
          {
             ImVec2 worldBound1 = worldToPos(aabb[i], boundsMVP);
             ImVec2 worldBound2 = worldToPos(aabb[(i + 1) % 4], boundsMVP);
-            if (!IsInContextRect(worldBound1) || !IsInContextRect(worldBound2))
+            if (!IsInContextRect(worldBound1) && !IsInContextRect(worldBound2))
             {
                continue;
             }


### PR DESCRIPTION
I think its the correct behavior since you can make them clip while moving and it looks odd.