### PR TITLE
Fixing warnings from msvc with /W4.

### DIFF
--- a/ImCurveEdit.cpp
+++ b/ImCurveEdit.cpp
@@ -301,7 +301,6 @@ namespace ImCurveEdit
             int originalIndex = 0;
             for (auto& sel : prevSelection)
             {
-               const ImVec2* pts = delegate.GetPoints(sel.curveIndex);
                const ImVec2 p = rangeToPoint(pointToRange(originalPoints[originalIndex]) + (io.MousePos - mousePosOrigin) * sizeOfPixel);
                const int newIndex = delegate.EditPoint(sel.curveIndex, sel.pointIndex, p);
                if (newIndex != sel.pointIndex)

--- a/ImCurveEdit.h
+++ b/ImCurveEdit.h
@@ -36,8 +36,8 @@ namespace ImCurveEdit
    {
       bool focused = false;
       virtual size_t GetCurveCount() = 0;
-      virtual bool IsVisible(size_t curveIndex) { return true; }
-      virtual CurveType GetCurveType(size_t curveIndex) const { return CurveLinear; }
+      virtual bool IsVisible(size_t /*curveIndex*/) { return true; }
+      virtual CurveType GetCurveType(size_t /*curveIndex*/) const { return CurveLinear; }
       virtual ImVec2& GetMin() = 0;
       virtual ImVec2& GetMax() = 0;
       virtual size_t GetPointCount(size_t curveIndex) = 0;

--- a/ImGradient.cpp
+++ b/ImGradient.cpp
@@ -15,7 +15,6 @@ namespace ImGradient
 
    static int DrawPoint(ImDrawList* draw_list, ImVec4 color, const ImVec2 size, bool editing, ImVec2 pos)
    {
-      int ret = 0;
       ImGuiIO& io = ImGui::GetIO();
 
       ImVec2 p1 = ImLerp(pos, ImVec2(pos + ImVec2(size.x - size.y, 0.f)), color.w) + ImVec2(3, 3);

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1202,7 +1202,7 @@ namespace ImGuizmo
 
          float angleStart = atan2f(cameraToModelNormalized[(4 - axis) % 3], cameraToModelNormalized[(3 - axis) % 3]) + ZPI * 0.5f;
 
-         for (unsigned int i = 0; i < circleMul * halfCircleSegmentCount + 1; i++)
+         for (int i = 0; i < circleMul * halfCircleSegmentCount + 1; i++)
          {
             float ng = angleStart + circleMul * ZPI * ((float)i / (float)halfCircleSegmentCount);
             vec_t axisPos = makeVect(cosf(ng), sinf(ng), 0.f);

--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -25,9 +25,6 @@ namespace ImSequencer
       return overDel;
    }
 
-   static int min(int a, int b) { return (a < b) ? a : b; }
-   static int max(int a, int b) { return (a > b) ? a : b; }
-
    bool Sequencer(SequenceInterface* sequence, int* currentFrame, bool* expanded, int* selectedEntry, int* firstFrame, int sequenceOptions)
    {
       bool ret = false;
@@ -75,7 +72,6 @@ namespace ImSequencer
       ImVector<CustomDraw> customDraws;
       ImVector<CustomDraw> compactCustomDraws;
       // zoom in/out
-      int frameOverCursor = 0;
       const int visibleFrameCount = (int)floorf((canvas_size.x - legendWidth) / framePixelWidth);
       const float barWidthRatio = ImMin(visibleFrameCount / (float)frameCount, 1.f);
       const float barWidthInPixels = barWidthRatio * (canvas_size.x - legendWidth);
@@ -222,7 +218,7 @@ namespace ImSequencer
 
          };
 
-         auto drawLineContent = [&](int i, int regionHeight) {
+         auto drawLineContent = [&](int i, int /*regionHeight*/) {
             int px = (int)canvas_pos.x + int(i * framePixelWidth) + legendWidth - int(firstFrameUsed * framePixelWidth);
             int tiretStart = int(contentMin.y);
             int tiretEnd = int(contentMax.y);
@@ -507,7 +503,6 @@ namespace ImSequencer
             ImVec2 scrollBarD(scrollBarMin.x + legendWidth + barWidthInPixels + startFrameOffset, scrollBarMax.y - 2);
             draw_list->AddRectFilled(scrollBarC, scrollBarD, (inScrollBar || MovingScrollBar) ? 0xFF606060 : 0xFF505050, 6);
 
-            float handleRadius = (scrollBarMax.y - scrollBarMin.y) / 2;
             ImRect barHandleLeft(scrollBarC, ImVec2(scrollBarC.x + 14, scrollBarD.y));
             ImRect barHandleRight(ImVec2(scrollBarD.x - 14, scrollBarC.y), scrollBarD);
 

--- a/ImZoomSlider.h
+++ b/ImZoomSlider.h
@@ -50,7 +50,7 @@ namespace ImZoomSlider
       static bool movingScrollBarSvg = false;
       static bool sizingRBarSvg = false;
       static bool sizingLBarSvg = false;
-      static ImGuiID editingId = -1;
+      static ImGuiID editingId = (ImGuiID)-1;
       static float scrollingSource = 0.f;
       static float saveViewLower;
       static float saveViewHigher;
@@ -172,7 +172,7 @@ namespace ImZoomSlider
          if (!io.MouseDown[0])
          {
             sizingRBarSvg = false;
-            editingId = -1;
+            editingId = (ImGuiID)-1;
          }
          else
          {
@@ -184,7 +184,7 @@ namespace ImZoomSlider
          if (!io.MouseDown[0])
          {
             sizingLBarSvg = false;
-            editingId = -1;
+            editingId = (ImGuiID)-1;
          }
          else
          {
@@ -198,7 +198,7 @@ namespace ImZoomSlider
             if (!io.MouseDown[0])
             {
                movingScrollBarSvg = false;
-               editingId = -1;
+               editingId = (ImGuiID)-1;
             }
             else
             {


### PR DESCRIPTION
```
ImCurveEdit.h(39,37): warning C4100: 'curveIndex': unreferenced formal parameter
ImCurveEdit.h(40,45): warning C4100: 'curveIndex': unreferenced formal parameter
ImCurveEdit.cpp(304,30): warning C4189: 'pts': local variable is initialized but not referenced
ImGradient.cpp(18,11): warning C4189: 'ret': local variable is initialized but not referenced
ImGuizmo.cpp(1205,37): warning C4018: '<': signed/unsigned mismatch
ImSequencer.cpp(236,10): warning C4100: 'regionHeight': unreferenced formal parameter
ImSequencer.cpp(78,11): warning C4189: 'frameOverCursor': local variable is initialized but not referenced
ImSequencer.cpp(510,19): warning C4189: 'handleRadius': local variable is initialized but not referenced
ImSequencer.cpp(28,15): warning C4505: 'ImSequencer::min': unreferenced local function has been removed
ImSequencer.cpp(29,15): warning C4505: 'ImSequencer::max': unreferenced local function has been removed
ImZoomSlider.h(53,1): warning C4245: 'initializing': conversion from 'int' to 'ImGuiID', signed/unsigned mismatch
ImZoomSlider.h(175,1): warning C4245: '=': conversion from 'int' to 'ImGuiID', signed/unsigned mismatch
ImZoomSlider.h(187,1): warning C4245: '=': conversion from 'int' to 'ImGuiID', signed/unsigned mismatch
ImZoomSlider.h(201,1): warning C4245: '=': conversion from 'int' to 'ImGuiID', signed/unsigned mismatch
```