### PR TITLE
ImSequencer: Ensure handles are a grabbable size

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -357,8 +357,12 @@ namespace ImSequencer
             {
                sequence->DoubleClick(i);
             }
-            ImRect rects[3] = { ImRect(slotP1, ImVec2(slotP1.x + framePixelWidth / 2, slotP2.y))
-                , ImRect(ImVec2(slotP2.x - framePixelWidth / 2, slotP1.y), slotP2)
+            // Ensure grabbable handles
+            const float max_handle_width = slotP2.x - slotP1.x / 3.0f;
+            const float min_handle_width = ImMin(10.0f, max_handle_width);
+            const float handle_width = ImClamp(framePixelWidth / 2.0f, min_handle_width, max_handle_width);
+            ImRect rects[3] = { ImRect(slotP1, ImVec2(slotP1.x + handle_width, slotP2.y))
+                , ImRect(ImVec2(slotP2.x - handle_width, slotP1.y), slotP2)
                 , ImRect(slotP1, slotP2) };
 
             const unsigned int quadColor[] = { 0xFFFFFFFF, 0xFFFFFFFF, slotColor + (selected ? 0 : 0x202020) };


### PR DESCRIPTION
Scaling with display sizes makes it too easy for them to become tiny and
useless. Instead, clamp the size within reasonable bounds.

This does pretty well at showing handles at near and far zoom.

# Before

![seq-tiny-handles](https://user-images.githubusercontent.com/43559/128589913-70812c57-ee80-4455-b1be-39c8172eb593.gif)


# After

![seq-big-handles](https://user-images.githubusercontent.com/43559/128589917-fa6dc624-fd1f-4069-a4e2-2316ae9560e0.gif)

(Gifs were made with `io.MouseDrawCursor = true`)