### PR TITLE
ImSequencer: Use more visible colors for +- buttons

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -40,7 +40,7 @@ namespace ImSequencer
       ImGuiIO& io = ImGui::GetIO();
       ImRect delRect(pos, ImVec2(pos.x + 16, pos.y + 16));
       bool overDel = delRect.Contains(io.MousePos);
-      int delColor = overDel ? 0xFFAAAAAA : 0x50000000;
+      int delColor = overDel ? 0xFFAAAAAA : 0x77A3B2AA;
       float midy = pos.y + 16 / 2 - 0.5f;
       float midx = pos.x + 16 / 2 - 0.5f;
       draw_list->AddRect(delRect.Min, delRect.Max, delColor, 4);


### PR DESCRIPTION
The + and - buttons are almost invisible with darker themes. Use a color
that stands out. The hover color is a red that doesn't match anything,
so I'm not using a lighter version of that -- picked something that
looks nice.

![image](https://user-images.githubusercontent.com/43559/128590066-d84485d2-7aec-4051-97b0-5289b71943e1.png)

I suppose the proper solution is to hook into imgui's theming, but that's too deep a hole for me today.