### PR TITLE
Fix interactions when clicking outside gizmo/manipulator or when they are obscured

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2837,7 +2837,7 @@ namespace IMGUIZMO_NAMESPACE
       isInside = ImRect(position, position + size).Contains(io.MousePos);
 
       // drag view
-      if (!isDraging && io.MouseDown[0] && isInside && (fabsf(io.MouseDelta.x) > 0.f || fabsf(io.MouseDelta.y) > 0.f))
+      if (!isDraging && io.MouseClicked[0] && isInside)
       {
          isDraging = true;
          isClicking = false;

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -680,7 +680,7 @@ namespace IMGUIZMO_NAMESPACE
 
       bool mbUsing;
       bool mbEnable;
-
+      bool mbMouseOver;
       bool mReversed; // reversed projection matrix
 
       // translation
@@ -890,6 +890,19 @@ namespace IMGUIZMO_NAMESPACE
       return IsWithin(p.x, gContext.mX, gContext.mXMax) && IsWithin(p.y, gContext.mY, gContext.mYMax);
    }
 
+   static bool IsHoveringWindow()
+   {
+      ImGuiContext& g = *ImGui::GetCurrentContext();
+      ImGuiWindow* window = ImGui::FindWindowByName(gContext.mDrawList->_OwnerName);
+      if (g.HoveredWindow == window)   // Mouse hovering drawlist window
+         return true;
+      if (g.HoveredWindow != NULL)     // Any other window is hovered
+         return false;
+      if (ImGui::IsMouseHoveringRect(window->InnerRect.Min, window->InnerRect.Max, false))   // Hovering drawlist window rect, while no other window is hovered (for _NoInputs windows)
+         return true;
+      return false;
+   }
+
    void SetRect(float x, float y, float width, float height)
    {
       gContext.mX = x;
@@ -988,6 +1001,7 @@ namespace IMGUIZMO_NAMESPACE
       gContext.mMode = mode;
       gContext.mViewMat = *(matrix_t*)view;
       gContext.mProjectionMat = *(matrix_t*)projection;
+      gContext.mbMouseOver = IsHoveringWindow();
 
       gContext.mModelLocal = *(matrix_t*)matrix;
       gContext.mModelLocal.OrthoNormalize();
@@ -1960,7 +1974,7 @@ namespace IMGUIZMO_NAMESPACE
 
    static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion)
    {
-      if(!Intersects(op, TRANSLATE) || gContext.mbUsing)
+      if(!Intersects(op, TRANSLATE) || gContext.mbUsing || !gContext.mbMouseOver)
       {
         return MT_NONE;
       }
@@ -2130,7 +2144,7 @@ namespace IMGUIZMO_NAMESPACE
 
    static bool HandleScale(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
    {
-      if((!Intersects(op, SCALE) && !Intersects(op, SCALEU)) || type != MT_NONE)
+      if((!Intersects(op, SCALE) && !Intersects(op, SCALEU)) || type != MT_NONE || !gContext.mbMouseOver)
       {
          return false;
       }
@@ -2243,7 +2257,7 @@ namespace IMGUIZMO_NAMESPACE
 
    static bool HandleRotation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
    {
-      if(!Intersects(op, ROTATE) || type != MT_NONE)
+      if(!Intersects(op, ROTATE) || type != MT_NONE || !gContext.mbMouseOver)
       {
         return false;
       }
@@ -2770,7 +2784,7 @@ namespace IMGUIZMO_NAMESPACE
                bool insidePanel = localx > panelCorners[0].x && localx < panelCorners[1].x&& localy > panelCorners[0].y && localy < panelCorners[1].y;
                int boxCoordInt = int(boxCoord.x * 9.f + boxCoord.y * 3.f + boxCoord.z);
                assert(boxCoordInt < 27);
-               boxes[boxCoordInt] |= insidePanel && (!isDraging);
+               boxes[boxCoordInt] |= insidePanel && (!isDraging) && gContext.mbMouseOver;
 
                // draw face with lighter color
                if (iPass)
@@ -2811,7 +2825,7 @@ namespace IMGUIZMO_NAMESPACE
                         interpolationFrames = 40;
                         isClicking = false;
                      }
-                     if (io.MouseDown[0] && !isDraging)
+                     if (io.MouseClicked[0] && !isDraging)
                      {
                         isClicking = true;
                      }
@@ -2834,7 +2848,7 @@ namespace IMGUIZMO_NAMESPACE
          vec_t newEye = camTarget + newDir * length;
          LookAt(&newEye.x, &camTarget.x, &newUp.x, view);
       }
-      isInside = ImRect(position, position + size).Contains(io.MousePos);
+      isInside = gContext.mbMouseOver && ImRect(position, position + size).Contains(io.MousePos);
 
       // drag view
       if (!isDraging && io.MouseClicked[0] && isInside)

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -275,18 +275,21 @@ void EditTransform(float* cameraView, float* cameraProjection, float* matrix, bo
    ImGuiIO& io = ImGui::GetIO();
    float viewManipulateRight = io.DisplaySize.x;
    float viewManipulateTop = 0;
+   static ImGuiWindowFlags gizmoWindowFlags = 0;
    if (useWindow)
    {
-      ImGui::SetNextWindowSize(ImVec2(800, 400));
-      ImGui::SetNextWindowPos(ImVec2(400,20));
+      ImGui::SetNextWindowSize(ImVec2(800, 400), ImGuiCond_Appearing);
+      ImGui::SetNextWindowPos(ImVec2(400,20), ImGuiCond_Appearing);
       ImGui::PushStyleColor(ImGuiCol_WindowBg, (ImVec4)ImColor(0.35f, 0.3f, 0.3f));
-      ImGui::Begin("Gizmo", 0, ImGuiWindowFlags_NoMove);
+      ImGui::Begin("Gizmo", 0, gizmoWindowFlags);
       ImGuizmo::SetDrawlist();
       float windowWidth = (float)ImGui::GetWindowWidth();
       float windowHeight = (float)ImGui::GetWindowHeight();
       ImGuizmo::SetRect(ImGui::GetWindowPos().x, ImGui::GetWindowPos().y, windowWidth, windowHeight);
       viewManipulateRight = ImGui::GetWindowPos().x + windowWidth;
       viewManipulateTop = ImGui::GetWindowPos().y;
+      ImGuiWindow* window = ImGui::GetCurrentWindow();
+      gizmoWindowFlags = ImGui::IsWindowHovered() && ImGui::IsMouseHoveringRect(window->InnerRect.Min, window->InnerRect.Max) ? ImGuiWindowFlags_NoMove : 0;
    }
    else
    {
@@ -756,12 +759,12 @@ int main(int, char**)
       ImGuizmo::SetOrthographic(!isPerspective);
       ImGuizmo::BeginFrame();
 
-      ImGui::SetNextWindowPos(ImVec2(1024, 100));
-      ImGui::SetNextWindowSize(ImVec2(256, 256));
+      ImGui::SetNextWindowPos(ImVec2(1024, 100), ImGuiCond_Appearing);
+      ImGui::SetNextWindowSize(ImVec2(256, 256), ImGuiCond_Appearing);
 
       // create a window and insert the inspector
-      ImGui::SetNextWindowPos(ImVec2(10, 10));
-      ImGui::SetNextWindowSize(ImVec2(320, 340));
+      ImGui::SetNextWindowPos(ImVec2(10, 10), ImGuiCond_Appearing);
+      ImGui::SetNextWindowSize(ImVec2(320, 340), ImGuiCond_Appearing);
       ImGui::Begin("Editor");
       if (ImGui::RadioButton("Full view", !useWindow)) useWindow = false;
       ImGui::SameLine();
@@ -821,9 +824,9 @@ int main(int, char**)
 
       ImGui::End();
 
-      ImGui::SetNextWindowPos(ImVec2(10, 350));
+      ImGui::SetNextWindowPos(ImVec2(10, 350), ImGuiCond_Appearing);
 
-      ImGui::SetNextWindowSize(ImVec2(940, 480));
+      ImGui::SetNextWindowSize(ImVec2(940, 480), ImGuiCond_Appearing);
       ImGui::Begin("Other controls");
       if (ImGui::CollapsingHeader("Zoom Slider"))
       {


### PR DESCRIPTION
This PR addresses following problems:
* Gizmo/manipulator reacting to mouse when obscured by other windows
* Gizmo/manipulator reacting to mouse even when mouse button was pressed down when outside of these widgets

A little less related change is allowing windows to move in example application. I needed this to test fixes listed above so i figured ill include the change. If you think that is not desirable, that commit may be dropped.