### PR TITLE
Fix division by zero in normalize when view and model matrices are identity

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -224,7 +224,7 @@ namespace IMGUIZMO_NAMESPACE
       const vec_t& operator + () const { return (*this); }
       float Length() const { return sqrtf(x * x + y * y + z * z); };
       float LengthSq() const { return (x * x + y * y + z * z); };
-      vec_t Normalize() { (*this) *= (1.f / ( Length() ? Length() : FLT_EPSILON ) ); return (*this); }
+      vec_t Normalize() { (*this) *= (1.f / ( Length() > FLT_EPSILON ? Length() : FLT_EPSILON ) ); return (*this); }
       vec_t Normalize(const vec_t& v) { this->Set(v.x, v.y, v.z, v.w); this->Normalize(); return (*this); }
       vec_t Abs() const;
 

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -224,7 +224,7 @@ namespace IMGUIZMO_NAMESPACE
       const vec_t& operator + () const { return (*this); }
       float Length() const { return sqrtf(x * x + y * y + z * z); };
       float LengthSq() const { return (x * x + y * y + z * z); };
-      vec_t Normalize() { (*this) *= (1.f / Length()); return (*this); }
+      vec_t Normalize() { (*this) *= (1.f / ( Length() ? Length() : FLT_EPSILON ) ); return (*this); }
       vec_t Normalize(const vec_t& v) { this->Set(v.x, v.y, v.z, v.w); this->Normalize(); return (*this); }
       vec_t Abs() const;
 


### PR DESCRIPTION
In ImGuizmo.cpp :
Calling `Manipulate()` with `view` and `matrix` both being identity matrices leads to the computation of :
`gContext.mModel.v.position - gContext.mCameraEye` 
being a zero vector when given as argument to `Normalized()` in `HandleTranslation()`, wich then leads to a division by zero inside the call to `Normalize()`.

Fixed by checking if the call to `Length()` results in zero, using `FLT_EPSILON` in this case, else the actual vector's length.