### PR TITLE
Mouse capture and finished drag

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2096,10 +2096,12 @@ namespace IMGUIZMO_NAMESPACE
          // find new possible way to move
          vec_t gizmoHitProportion;
          type = GetMoveType(op, &gizmoHitProportion);
+#ifdef IMGUIZMO_MOUSE_CAPTURE_ON_HOVER
          if (type != MT_NONE)
          {
             ImGui::CaptureMouseFromApp();
          }
+#endif
          if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
@@ -2141,10 +2143,12 @@ namespace IMGUIZMO_NAMESPACE
       {
          // find new possible way to scale
          type = GetScaleType(op);
+#ifdef IMGUIZMO_MOUSE_CAPTURE_ON_HOVER
          if (type != MT_NONE)
          {
             ImGui::CaptureMouseFromApp();
          }
+#endif
          if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
@@ -2254,12 +2258,12 @@ namespace IMGUIZMO_NAMESPACE
       if (!gContext.mbUsing)
       {
          type = GetRotateType(op);
-
+#ifdef IMGUIZMO_MOUSE_CAPTURE_ON_HOVER
          if (type != MT_NONE)
          {
             ImGui::CaptureMouseFromApp();
          }
-
+#endif
          if (type == MT_ROTATE_SCREEN)
          {
             applyRotationLocaly = true;

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -115,6 +115,8 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 #define IMGUIZMO_NAMESPACE ImGuizmo
 #endif
 
+#define IMGUIZMO_MOUSE_CAPTURE_ON_HOVER
+
 namespace IMGUIZMO_NAMESPACE
 {
    // call inside your own window and before Manipulate() in order to draw gizmo to that window.

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -115,7 +115,7 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 #define IMGUIZMO_NAMESPACE ImGuizmo
 #endif
 
-#define IMGUIZMO_MOUSE_CAPTURE_ON_HOVER
+//#define IMGUIZMO_NO_MOUSE_CAPTURE_ON_HOVER
 
 namespace IMGUIZMO_NAMESPACE
 {
@@ -137,6 +137,13 @@ namespace IMGUIZMO_NAMESPACE
 
    // return true if mouse IsOver or if the gizmo is in moving state
    IMGUI_API bool IsUsing();
+
+   // return true if a dragging event is finished
+   // this will only be set for the one frame it has finished
+   bool FinishedDragging();
+
+   // get the transformation matrix for the finished drag
+   void GetFinishedDragMatrix(float* dragMatrix);
 
    // enable/disable the gizmo. Stay in the state until next call to Enable.
    // gizmo is rendered with gray half transparent color when disabled


### PR DESCRIPTION
Hi! Mouse capture on hover is now turned on per default with an option to turn it off.
Also i'm trying to get a matrix that represents an entire "drag", making it easy to record the action
for easy undo/redo functionality.

`if (ImGuizmo::FinishedDragging())
{
   XMFLOAT4X4 drag_matrix;
   ImGuizmo::GetFinishedDragMatrix(&drag_matrix._11);
   SaveToHistory(CHANGE_TRANSLATION, drag_matrix);
}`

Not sure this is the best way, sence it requires deltaMatrix to allways be computed. Any suggestions?