### PR TITLE
Replace assert call with IM_ASSERT

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2784,7 +2784,7 @@ namespace IMGUIZMO_NAMESPACE
                const ImVec2 panelCorners[2] = { panelPosition[iPanel], panelPosition[iPanel] + panelSize[iPanel] };
                bool insidePanel = localx > panelCorners[0].x && localx < panelCorners[1].x&& localy > panelCorners[0].y && localy < panelCorners[1].y;
                int boxCoordInt = int(boxCoord.x * 9.f + boxCoord.y * 3.f + boxCoord.z);
-               assert(boxCoordInt < 27);
+               IM_ASSERT(boxCoordInt < 27);
                boxes[boxCoordInt] |= insidePanel && (!isDraging) && gContext.mbMouseOver;
 
                // draw face with lighter color


### PR DESCRIPTION
If `IM_ASSERT` is customized to not use `cassert` the current code fails to compile due `cassert` not being included. This is solveable by including `cassert`/`assert.h` but I think the better option would be to use `IM_ASSERT` directly and this pull request does that.