### PR TITLE
Fix empty labels in sample for imgui v1.86 and later an assertion

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -246,7 +246,7 @@ void EditTransform(float* cameraView, float* cameraProjection, float* matrix, bo
       }
       if (ImGui::IsKeyPressed(83))
          useSnap = !useSnap;
-      ImGui::Checkbox("", &useSnap);
+      ImGui::Checkbox("##UseSnap", &useSnap);
       ImGui::SameLine();
 
       switch (mCurrentGizmoOperation)
@@ -265,7 +265,7 @@ void EditTransform(float* cameraView, float* cameraProjection, float* matrix, bo
       if (boundSizing)
       {
          ImGui::PushID(3);
-         ImGui::Checkbox("", &boundSizingSnap);
+         ImGui::Checkbox("##BoundSizing", &boundSizingSnap);
          ImGui::SameLine();
          ImGui::InputFloat3("Snap", boundsSnap);
          ImGui::PopID();


### PR DESCRIPTION
https://github.com/ocornut/imgui/commit/c80179921819818c9743f168ceae6f300851b014

I have confirmed that it works with 1.87 and 1.84 (in this repos).