### PR TITLE
Fixed rendering rotation guizmo by orthographic camera.

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1201,7 +1201,7 @@ namespace IMGUIZMO_NAMESPACE
       {
          matrix_t viewInverse;
          viewInverse.Inverse(*(matrix_t*)&gContext.mViewMat);
-         cameraToModelNormalized = viewInverse.v.dir;
+         cameraToModelNormalized = -viewInverse.v.dir;
       }
       else
       {


### PR DESCRIPTION
When changing camera to orthographic, rotation gizmo was rendered as seen from the back. View inverse is just camera transformation but the convention is that +Z is pointing *behind* camera. This is probably why gizmo is rendered from back.

Related to: #182, #165