### PR TITLE
Fix obsolete functions for latest ImGui version

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -422,7 +422,11 @@ namespace ImSequencer
          // moving
          if (/*backgroundRect.Contains(io.MousePos) && */movingEntry >= 0)
          {
+#if IMGUI_VERSION_NUM >= 18723
+            ImGui::SetNextFrameWantCaptureMouse(true);
+#else
             ImGui::CaptureMouseFromApp();
+#endif
             int diffFrame = int((cx - movingPos) / framePixelWidth);
             if (std::abs(diffFrame) > 0)
             {


### PR DESCRIPTION
Similarly to commit aefb7ebd81284d5aeec7cbe0a29da8561521f8b7, this fixes a call to the obsolete `CaptureMouseFromApp`.

Most of these calls were already fixed in the aforementioned commit, but the one in `ImSequencer.cpp` was missed.