### PR TITLE
Hatched axis lines no longer render if `HatchedAxisLineThickness` is …

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1315,6 +1315,11 @@ namespace IMGUIZMO_NAMESPACE
 
    static void DrawHatchedAxis(const vec_t& axis)
    {
+      if (gContext.mStyle.HatchedAxisLineThickness <= 0.0f)
+      {
+         return;
+      }
+
       for (int j = 1; j < 10; j++)
       {
          ImVec2 baseSSpace2 = worldToPos(axis * 0.05f * (float)(j * 2) * gContext.mScreenFactor, gContext.mMVP);


### PR DESCRIPTION
…<= 0

Setting `ImGuizmo::Style::HatchedAxisLineThickness` to <= 0 now prevents the hatched lines from rendering completely, instead of rendering at a thickness of 1 (See `ImGui::AddPolyline`)