### PR TITLE
ImSequencer: Clicks must start inside button; animate buttons

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -38,16 +38,16 @@ namespace ImSequencer
    static bool SequencerAddDelButton(ImDrawList* draw_list, ImVec2 pos, bool add = true)
    {
       ImGuiIO& io = ImGui::GetIO();
-      ImRect delRect(pos, ImVec2(pos.x + 16, pos.y + 16));
-      bool overDel = delRect.Contains(io.MousePos);
-      int delColor = overDel ? 0xFFAAAAAA : 0x77A3B2AA;
+      ImRect btnRect(pos, ImVec2(pos.x + 16, pos.y + 16));
+      bool overBtn = btnRect.Contains(io.MousePos);
+      int btnColor = overBtn ? 0xFFAAAAAA : 0x77A3B2AA;
       float midy = pos.y + 16 / 2 - 0.5f;
       float midx = pos.x + 16 / 2 - 0.5f;
-      draw_list->AddRect(delRect.Min, delRect.Max, delColor, 4);
-      draw_list->AddLine(ImVec2(delRect.Min.x + 3, midy), ImVec2(delRect.Max.x - 3, midy), delColor, 2);
+      draw_list->AddRect(btnRect.Min, btnRect.Max, btnColor, 4);
+      draw_list->AddLine(ImVec2(btnRect.Min.x + 3, midy), ImVec2(btnRect.Max.x - 3, midy), btnColor, 2);
       if (add)
-         draw_list->AddLine(ImVec2(midx, delRect.Min.y + 3), ImVec2(midx, delRect.Max.y - 3), delColor, 2);
-      return overDel;
+         draw_list->AddLine(ImVec2(midx, btnRect.Min.y + 3), ImVec2(midx, btnRect.Max.y - 3), btnColor, 2);
+      return overBtn;
    }
 
    bool Sequencer(SequenceInterface* sequence, int* currentFrame, bool* expanded, int* selectedEntry, int* firstFrame, int sequenceOptions)

--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -40,14 +40,17 @@ namespace ImSequencer
       ImGuiIO& io = ImGui::GetIO();
       ImRect btnRect(pos, ImVec2(pos.x + 16, pos.y + 16));
       bool overBtn = btnRect.Contains(io.MousePos);
-      int btnColor = overBtn ? 0xFFAAAAAA : 0x77A3B2AA;
+      bool containedClick = overBtn && btnRect.Contains(io.MouseClickedPos[0]);
+      bool clickedBtn = containedClick && io.MouseReleased[0];
+      int btnColor = overBtn ? 0xAAEAFFAA : 0x77A3B2AA;
+
       float midy = pos.y + 16 / 2 - 0.5f;
       float midx = pos.x + 16 / 2 - 0.5f;
       draw_list->AddRect(btnRect.Min, btnRect.Max, btnColor, 4);
       draw_list->AddLine(ImVec2(btnRect.Min.x + 3, midy), ImVec2(btnRect.Max.x - 3, midy), btnColor, 2);
       if (add)
          draw_list->AddLine(ImVec2(midx, btnRect.Min.y + 3), ImVec2(midx, btnRect.Max.y - 3), btnColor, 2);
-      return overBtn;
+      return clickedBtn;
    }
 
    bool Sequencer(SequenceInterface* sequence, int* currentFrame, bool* expanded, int* selectedEntry, int* firstFrame, int sequenceOptions)
@@ -193,7 +196,7 @@ namespace ImSequencer
          draw_list->AddRectFilled(canvas_pos, ImVec2(canvas_size.x + canvas_pos.x, canvas_pos.y + ItemHeight), 0xFF3D3837, 0);
          if (sequenceOptions & SEQUENCER_ADD)
          {
-            if (SequencerAddDelButton(draw_list, ImVec2(canvas_pos.x + legendWidth - ItemHeight, canvas_pos.y + 2), true) && io.MouseReleased[0])
+            if (SequencerAddDelButton(draw_list, ImVec2(canvas_pos.x + legendWidth - ItemHeight, canvas_pos.y + 2), true))
                ImGui::OpenPopup("addEntry");
 
             if (ImGui::BeginPopup("addEntry"))
@@ -280,12 +283,10 @@ namespace ImSequencer
 
             if (sequenceOptions & SEQUENCER_DEL)
             {
-               bool overDel = SequencerAddDelButton(draw_list, ImVec2(contentMin.x + legendWidth - ItemHeight + 2 - 10, tpos.y + 2), false);
-               if (overDel && io.MouseReleased[0])
+               if (SequencerAddDelButton(draw_list, ImVec2(contentMin.x + legendWidth - ItemHeight + 2 - 10, tpos.y + 2), false))
                   delEntry = i;
 
-               bool overDup = SequencerAddDelButton(draw_list, ImVec2(contentMin.x + legendWidth - ItemHeight - ItemHeight + 2 - 10, tpos.y + 2), true);
-               if (overDup && io.MouseReleased[0])
+               if (SequencerAddDelButton(draw_list, ImVec2(contentMin.x + legendWidth - ItemHeight - ItemHeight + 2 - 10, tpos.y + 2), true))
                   dupEntry = i;
             }
             customHeight += sequence->GetCustomHeight(i);
@@ -675,8 +676,7 @@ namespace ImSequencer
 
       if (expanded)
       {
-         bool overExpanded = SequencerAddDelButton(draw_list, ImVec2(canvas_pos.x + 2, canvas_pos.y + 2), !*expanded);
-         if (overExpanded && io.MouseReleased[0])
+         if (SequencerAddDelButton(draw_list, ImVec2(canvas_pos.x + 2, canvas_pos.y + 2), !*expanded))
             *expanded = !*expanded;
       }
 

--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -43,6 +43,8 @@ namespace ImSequencer
       bool containedClick = overBtn && btnRect.Contains(io.MouseClickedPos[0]);
       bool clickedBtn = containedClick && io.MouseReleased[0];
       int btnColor = overBtn ? 0xAAEAFFAA : 0x77A3B2AA;
+      if (containedClick && io.MouseDownDuration[0] > 0)
+         btnRect.Expand(2.0f);
 
       float midy = pos.y + 16 / 2 - 0.5f;
       float midx = pos.x + 16 / 2 - 0.5f;


### PR DESCRIPTION
- Fix dragging a ImSequencer track start over the remove button and releasing deletes the track.
  - This issue caused a lot of headaches because users didn't understand why they were losing data.
- Fix clicking on ImSequencer duplicate and dragging off to cancel removes the track if you released over the remove button.

Now SequencerAddDelButton behaves like ImGui:Button: requires the click to start inside the button and end inside the button.

When you click a button, expand its size to give feedback that it's pressed.

Bug:

https://user-images.githubusercontent.com/43559/197356263-f66685ff-9da7-4178-bc7d-16b55dce7733.mp4

Fixed:

https://user-images.githubusercontent.com/43559/197356264-9607883f-106f-4ffe-910f-74c9a0ab8321.mp4

Animation:

![seq-btn-anim](https://user-images.githubusercontent.com/43559/197356712-e910fca0-426b-4d0d-a217-826a71963d8d.gif)



Test
Build imguizmo test app.
* Click drag track start and end.
* Click expand, add, duplicate, and remove buttons.
* Click drag off remove button.
* Click drag track start over remove button.
