### PR TITLE
ImSequencer: Fix clip when scrolling out of view

### DIFF
--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -328,7 +328,7 @@ namespace ImSequencer
          {
             customHeight = 0;
             for (int i = 0; i < *selectedEntry; i++)
-               customHeight += sequence->GetCustomHeight(i);;
+               customHeight += sequence->GetCustomHeight(i);
             draw_list->AddRectFilled(ImVec2(contentMin.x, contentMin.y + ItemHeight * *selectedEntry + customHeight), ImVec2(contentMin.x + canvas_size.x, contentMin.y + ItemHeight * (*selectedEntry + 1) + customHeight), 0x801080FF, 1.f);
          }
 

--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -267,7 +267,7 @@ namespace ImSequencer
                   */
                   // clip content
 
-         draw_list->PushClipRect(childFramePos, childFramePos + childFrameSize);
+         draw_list->PushClipRect(childFramePos, childFramePos + childFrameSize, true);
 
          // draw item names in the legend rect on the left
          size_t customHeight = 0;
@@ -291,9 +291,6 @@ namespace ImSequencer
             customHeight += sequence->GetCustomHeight(i);
          }
 
-         // clipping rect so items bars are not visible in the legend on the left when scrolled
-         //
-
          // slots background
          customHeight = 0;
          for (int i = 0; i < sequenceCount; i++)
@@ -312,7 +309,7 @@ namespace ImSequencer
             customHeight += localCustomHeight;
          }
 
-         draw_list->PushClipRect(childFramePos + ImVec2(float(legendWidth), 0.f), childFramePos + childFrameSize);
+         draw_list->PushClipRect(childFramePos + ImVec2(float(legendWidth), 0.f), childFramePos + childFrameSize, true);
 
          // vertical frame lines in content area
          for (int i = sequence->GetFrameMin(); i <= sequence->GetFrameMax(); i += frameStep)


### PR DESCRIPTION
Fix failure to clip within our parent when using BeginChild.

This is a reimplementation of #57 which no longer merges cleanly.
It pulls simpler changes out of #195 to get them merged. See https://github.com/CedricGuillemet/ImGuizmo/pull/195#issuecomment-895619149.

It's just passing true for `intersect_with_current_clip_rect` in PushClipRect and removing an outdated comment. I've been using this (via #195 for a year and it's worked well).

## Test case
Build sample app but with this sequencer section:

```
if (ImGui::CollapsingHeader("Sequencer"))
{
   // let's create the sequencer
   static int selectedEntry = -1;
   static int firstFrame = 0;
   static bool expanded = true;
   static int currentFrame = 100;
   static bool was_expanded = false;
   ImVec2 sequencer_size = ImGui::GetContentRegionAvail();
   sequencer_size.y -= 20;
   if (was_expanded) {
      sequencer_size.y -= 25 * 2;
   }

   ImGui::BeginChild("Sequencer", sequencer_size);
   {
      Sequencer(&mySequence, &currentFrame, &expanded, &selectedEntry, &firstFrame, ImSequencer::SEQUENCER_EDIT_ALL);
   }
   ImGui::EndChild();

   was_expanded = ImGui::CollapsingHeader("Colors");
   if (was_expanded) {
      static float color[4] = { 0, 0, 0, 0, };
      for (int i = 0; i < 10; ++i) {
         ImGui::ColorEdit4("Color", color);
      }
   }
}
```

### Before

<img width="752" alt="image" src="https://user-images.githubusercontent.com/43559/197358215-536a95bd-3980-4871-b00d-3414d3ea4cfd.png">


### After 

<img width="734" alt="image" src="https://user-images.githubusercontent.com/43559/197358221-90554688-4267-4451-8271-e306b1dd6566.png">
