### PR TITLE
Add virtual destructors to delegates

### DIFF
--- a/GraphEditor.h
+++ b/GraphEditor.h
@@ -139,6 +139,8 @@ struct Delegate
     
     virtual const size_t GetLinkCount() = 0;
     virtual const Link GetLink(LinkIndex index) = 0;
+
+    virtual ~Delegate() = default;
 };
 
 void Show(Delegate& delegate, const Options& options, ViewState& viewState, bool enabled, FitOnScreen* fit = nullptr);

--- a/ImCurveEdit.h
+++ b/ImCurveEdit.h
@@ -74,6 +74,8 @@ namespace ImCurveEdit
       // handle undo/redo thru this functions
       virtual void BeginEdit(int /*index*/) {}
       virtual void EndEdit() {}
+
+      virtual ~Delegate() = default;
    };
 
    int Edit(Delegate& delegate, const ImVec2& size, unsigned int id, const ImRect* clippingRect = NULL, ImVector<EditPoint>* selectedPoints = NULL);

--- a/ImGradient.h
+++ b/ImGradient.h
@@ -38,6 +38,7 @@ namespace ImGradient
       virtual int EditPoint(int pointIndex, ImVec4 value) = 0;
       virtual ImVec4 GetPoint(float t) = 0;
       virtual void AddPoint(ImVec4 value) = 0;
+      virtual ~Delegate() = default;
    };
 
    bool Edit(Delegate& delegate, const ImVec2& size, int& selection);

--- a/ImSequencer.h
+++ b/ImSequencer.h
@@ -68,6 +68,8 @@ namespace ImSequencer
       virtual void DoubleClick(int /*index*/) {}
       virtual void CustomDraw(int /*index*/, ImDrawList* /*draw_list*/, const ImRect& /*rc*/, const ImRect& /*legendRect*/, const ImRect& /*clippingRect*/, const ImRect& /*legendClippingRect*/) {}
       virtual void CustomDrawCompact(int /*index*/, ImDrawList* /*draw_list*/, const ImRect& /*rc*/, const ImRect& /*clippingRect*/) {}
+
+       virtual ~SequenceInterface() = default;
    };
 
 


### PR DESCRIPTION
Hi,

This is just a simple modification, in order to resolve some warnings. 
I might not be the first to mention this, and you might have decided to ignore this warning (in this case, I will add a flag to discard it in my code base).

--- 
Some compiler wine about the missing virtual destructor. In realistic cases this is not an issue, but might become one if someone decides to store and later free a pointer to the Delegate instead of their own  derivate.