### PR TITLE
Check if any ImGui widget is active before setting the dragging state for ViewManipulate

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2872,7 +2872,7 @@ namespace IMGUIZMO_NAMESPACE
                   {
                      gContext.mDrawList->AddConvexPolyFilled(faceCoordsScreen, 4, IM_COL32(0xF0, 0xA0, 0x60, 0x80));
 
-                     if (io.MouseDown[0] && !isClicking && !isDraging) {
+                     if (io.MouseDown[0] && !isClicking && !isDraging && GImGui->ActiveId == 0) {
                         overBox = boxCoordInt;
                         isClicking = true;
                         isDraging = true;


### PR DESCRIPTION
fixes #279 and other issues when dragging while an imgui widget is active like slider or drag scalar.