### PR TITLE
Fixed ImGuizmo::IsOver ignores ImGuizmo::SetID state

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -982,7 +982,7 @@ namespace IMGUIZMO_NAMESPACE
 
    bool IsUsing()
    {
-      return gContext.mbUsing || gContext.mbUsingBounds;
+      return (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID)) || gContext.mbUsingBounds;
    }
 
    bool IsOver()


### PR DESCRIPTION
Thank you for this amazing library - it has been extremely useful in my software!

This PR is a casual suggestion for making `ImGuizmo::IsUsing` respect `ImGuizmo::SetID()`. The idea being that calling `IsUsing` when an ID is set should only return `true` if the gizmo with that ID is the one currently being manipulated.

I'm not married to this implementation/fix and I'd welcome any alternate approaches (maybe I missed something). The reason I ultimately need it is because I'm using `IsUsing` to implement something similar to `ImGui::IsItemDeactivatedAfterEdit` (longer explanation below).

# Context (if it's handy)

Just for some context, I develop [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator), which uses `ImGuizmo` internally. Here's a screenshot of it in use:

![imguizmo_screenshot](https://user-images.githubusercontent.com/4730570/220125049-925f4b7a-9c9d-44f2-9fc9-ea65e75a6884.png)

The UI supports multiple viewports, and the ImGuizmo-to-application interaction I need is similar to ImGui's `IsItemDeactivatedAfterEdit` function, which is that I need a flow like:

- For each viewport
  - Show the gizmo in that viewport (i.e. with help from `ImGuizmo::SetID`)
  - If the user manipulates a gizmo, apply the manipulation to some kind of "scatch space" for the document
  - Once the user finishes manipulating a gizmo, save the "scratch space" to undo/redo storage

And the way I'm doing that is to keep track of state using `bool usingThisFrame = ImGuizmo::IsUsing(); if (usingThisFrame && !m_WasUsingLastFrame) { saveToUndoRedo(); } m_WasUsingLastFrame = usingThisFrame;`. The exact code I'm using to do that is [here](https://github.com/ComputationalBiomechanicsLab/opensim-creator/blob/57f48ebbd92d35f2b0ebf85ae88227074521dc2f/src/OpenSimBindings/Widgets/ModelSelectionGizmo.cpp#L563), but it fails (by saving multiple times) when multiple gizmos are shown, because `IsUsing` will return `true` for all viewports - even if only one viewport is actually using a gizmo.

