### PR TITLE
Fixes for requirement to define IMGUI_DEFINE_MATH_OPERATORS before imgui.h

### DIFF
--- a/GraphEditor.cpp
+++ b/GraphEditor.cpp
@@ -24,8 +24,8 @@
 // SOFTWARE.
 //
 
-#include "imgui.h"
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui.h"
 #include "imgui_internal.h"
 #include <math.h>
 #include <vector>

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -24,10 +24,10 @@
 // SOFTWARE.
 //
 
-#include "imgui.h"
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif
+#include "imgui.h"
 #include "imgui_internal.h"
 #include "ImGuizmo.h"
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -23,8 +23,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-#include "imgui.h"
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui.h"
 #include "imgui_internal.h"
 #define IMAPP_IMPL
 #include "ImApp.h"

--- a/vcpkg-example/main.cpp
+++ b/vcpkg-example/main.cpp
@@ -1,5 +1,5 @@
-#include "imgui.h"
 #define IMGUI_DEFINE_MATH_OPERATORS
+#include "imgui.h"
 #include "imgui_internal.h"
 #define IMAPP_IMPL
 #include "ImApp.h"


### PR DESCRIPTION
The ImGuizmo fix should work with older imgui version.

Changed by
https://github.com/ocornut/imgui/commit/a1b8457cb5c9238f47fc7616e84c0775412ce556

(same as https://github.com/epezent/implot/pull/449)

