### PR TITLE
WIP: stateless calculation for display-constant gizmo

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2063,8 +2063,10 @@ namespace IMGUIZMO_NAMESPACE
             type = MT_MOVE_X + i;
          }
 
-         const float dx = dirPlaneX.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
-         const float dy = dirPlaneY.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
+         float ratio_x = dirPlaneX.Length();
+         float ratio_y = dirPlaneY.Length();
+         const float dx = dirPlaneX.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / (gContext.mScreenFactor * ratio_x)));
+         const float dy = dirPlaneY.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / (gContext.mScreenFactor * ratio_y)));
          
          std::cout << dirPlaneX.x << " " << dirPlaneX.y << " " << dirPlaneX.z << std::endl;
          std::cout << dirPlaneY.x << " " << dirPlaneY.y << " " << dirPlaneY.z << std::endl;

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2063,16 +2063,12 @@ namespace IMGUIZMO_NAMESPACE
             type = MT_MOVE_X + i;
          }
 
+         // Reverse the ratio of dirPlane by 1 so that selected point could be at the right place.
          float ratio_x = dirPlaneX.Length();
          float ratio_y = dirPlaneY.Length();
-         const float dx = dirPlaneX.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / (gContext.mScreenFactor * ratio_x)));
-         const float dy = dirPlaneY.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / (gContext.mScreenFactor * ratio_y)));
+         const float dx = dirPlaneX.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / (gContext.mScreenFactor * ratio_x * ratio_x)));
+         const float dy = dirPlaneY.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / (gContext.mScreenFactor * ratio_y * ratio_y)));
          
-         std::cout << dirPlaneX.x << " " << dirPlaneX.y << " " << dirPlaneX.z << std::endl;
-         std::cout << dirPlaneY.x << " " << dirPlaneY.y << " " << dirPlaneY.z << std::endl;
-         std::cout <<(posOnPlan - gContext.mModel.v.position).x << " " << (posOnPlan - gContext.mModel.v.position).y << " " << (posOnPlan - gContext.mModel.v.position).z << std::endl;
-         std::cout << dx << " " << dy << std::endl << "---------" << std::endl;
-
          if (belowPlaneLimit && dx >= quadUV[0] && dx <= quadUV[4] && dy >= quadUV[1] && dy <= quadUV[3] && Contains(op, TRANSLATE_PLANS[i]))
          {
             type = MT_MOVE_YZ + i;

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2063,8 +2063,8 @@ namespace IMGUIZMO_NAMESPACE
             type = MT_MOVE_X + i;
          }
 
-         const float dx = dirPlaneX.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
-         const float dy = dirPlaneY.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
+         const float dx = dirPlaneX.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
+         const float dy = dirPlaneY.Normalize().Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
          
          std::cout << dirPlaneX.x << " " << dirPlaneX.y << " " << dirPlaneX.z << std::endl;
          std::cout << dirPlaneY.x << " " << dirPlaneY.y << " " << dirPlaneY.z << std::endl;

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -24,6 +24,8 @@
 // SOFTWARE.
 //
 
+#include <iostream>
+
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif
@@ -1129,7 +1131,7 @@ namespace IMGUIZMO_NAMESPACE
       }
    }
 
-   static void ComputeTripodAxisAndVisibility(const int axisIndex, vec_t& dirAxis, vec_t& dirPlaneX, vec_t& dirPlaneY, bool& belowAxisLimit, bool& belowPlaneLimit, const bool localCoordinates = false)
+   static void ComputeTripodAxisAndVisibility(const int axisIndex, vec_t& dirAxis, vec_t& dirPlaneX, vec_t& dirPlaneY, bool& belowAxisLimit, bool& belowPlaneLimit, const bool localCoordinates = false, CONSTANCY constancy = SCALE_CONST)
    {
       dirAxis = directionUnary[axisIndex];
       dirPlaneX = directionUnary[(axisIndex + 1) % 3];
@@ -1156,6 +1158,8 @@ namespace IMGUIZMO_NAMESPACE
 
          float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY, localCoordinates);
          float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY, localCoordinates);
+
+         std::cout << lenDir << " " << lenDirMinus << " " << lenDirPlaneX << " " << lenDirMinusPlaneX << " " << lenDirPlaneY << " " << lenDirMinusPlaneY << std::endl;
 
          // For readability
          bool & allowFlip = gContext.mAllowAxisFlip;
@@ -1500,7 +1504,7 @@ namespace IMGUIZMO_NAMESPACE
       }
    }
 
-   static void DrawTranslationGizmo(OPERATION op, int type)
+   static void DrawTranslationGizmo(OPERATION op, int type, CONSTANCY constancy)
    {
       ImDrawList* drawList = gContext.mDrawList;
       if (!drawList)
@@ -2481,7 +2485,7 @@ namespace IMGUIZMO_NAMESPACE
      gContext.mAllowAxisFlip = value;
    }
 
-   bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix, const float* snap, const float* localBounds, const float* boundsSnap)
+   bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix, const float* snap, const float* localBounds, const float* boundsSnap, CONSTANCY constancy)
    {
       // Scale is always local or matrix will be skewed when applying world scale or oriented matrix
       ComputeContext(view, projection, matrix, (operation & SCALE) ? LOCAL : mode);
@@ -2522,7 +2526,7 @@ namespace IMGUIZMO_NAMESPACE
       if (!gContext.mbUsingBounds)
       {
          DrawRotationGizmo(operation, type);
-         DrawTranslationGizmo(operation, type);
+         DrawTranslationGizmo(operation, type, constancy);
          DrawScaleGizmo(operation, type);
          DrawScaleUniveralGizmo(operation, type);
       }

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1150,7 +1150,12 @@ namespace IMGUIZMO_NAMESPACE
       else
       {
          // new method
-         float scale_factor = std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 0], std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 1], (gContext.mViewMat.m16)[axisIndex * 4 + 2]));
+         float scale_factor = 1.0f;
+         if (constancy == DISPLAY_CONST)
+         {
+            float scale_factor = std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 0], std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 1], (gContext.mViewMat.m16)[axisIndex * 4 + 2]));
+         }
+
          float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates);
          float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates);
 
@@ -1168,8 +1173,6 @@ namespace IMGUIZMO_NAMESPACE
          dirAxis *= mulAxis / scale_factor;
          dirPlaneX *= mulAxisX / scale_factor;
          dirPlaneY *= mulAxisY / scale_factor;
-
-         std::cout << gContext.mScreenFactor << std::endl;
 
          // for axis
          float axisLengthInClipSpace = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis * gContext.mScreenFactor, localCoordinates);
@@ -1227,7 +1230,7 @@ namespace IMGUIZMO_NAMESPACE
       return angle;
    }
 
-   static void DrawRotationGizmo(OPERATION op, int type)
+   static void DrawRotationGizmo(OPERATION op, int type, CONSTANCY constancy = SCALE_CONST)
    {
       if(!Intersects(op, ROTATE))
       {
@@ -1333,7 +1336,7 @@ namespace IMGUIZMO_NAMESPACE
       }
    }
 
-   static void DrawScaleGizmo(OPERATION op, int type)
+   static void DrawScaleGizmo(OPERATION op, int type, CONSTANCY constancy = SCALE_CONST)
    {
       ImDrawList* drawList = gContext.mDrawList;
 
@@ -1365,7 +1368,7 @@ namespace IMGUIZMO_NAMESPACE
          {
             vec_t dirPlaneX, dirPlaneY, dirAxis;
             bool belowAxisLimit, belowPlaneLimit;
-            ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+            ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true, constancy);
 
             // draw axis
             if (belowAxisLimit)
@@ -1421,7 +1424,7 @@ namespace IMGUIZMO_NAMESPACE
    }
 
 
-   static void DrawScaleUniveralGizmo(OPERATION op, int type)
+   static void DrawScaleUniveralGizmo(OPERATION op, int type, CONSTANCY constancy = SCALE_CONST)
    {
       ImDrawList* drawList = gContext.mDrawList;
 
@@ -1453,7 +1456,7 @@ namespace IMGUIZMO_NAMESPACE
          {
             vec_t dirPlaneX, dirPlaneY, dirAxis;
             bool belowAxisLimit, belowPlaneLimit;
-            ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+            ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true, constancy);
 
             // draw axis
             if (belowAxisLimit)
@@ -1505,7 +1508,7 @@ namespace IMGUIZMO_NAMESPACE
       }
    }
 
-   static void DrawTranslationGizmo(OPERATION op, int type, CONSTANCY constancy)
+   static void DrawTranslationGizmo(OPERATION op, int type, CONSTANCY constancy = SCALE_CONST)
    {
       ImDrawList* drawList = gContext.mDrawList;
       if (!drawList)
@@ -1530,7 +1533,7 @@ namespace IMGUIZMO_NAMESPACE
       for (int i = 0; i < 3; ++i)
       {
          vec_t dirPlaneX, dirPlaneY, dirAxis;
-         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, false, constancy);
 
          if (!gContext.mbUsing || (gContext.mbUsing && type == MT_MOVE_X + i))
          {
@@ -2526,10 +2529,10 @@ namespace IMGUIZMO_NAMESPACE
       gContext.mOperation = operation;
       if (!gContext.mbUsingBounds)
       {
-         DrawRotationGizmo(operation, type);
+         DrawRotationGizmo(operation, type, constancy);
          DrawTranslationGizmo(operation, type, constancy);
-         DrawScaleGizmo(operation, type);
-         DrawScaleUniveralGizmo(operation, type);
+         DrawScaleGizmo(operation, type, constancy);
+         DrawScaleUniveralGizmo(operation, type, constancy);
       }
       return manipulated;
    }

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1150,14 +1150,15 @@ namespace IMGUIZMO_NAMESPACE
       else
       {
          // new method
-         float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates);
-         float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates);
+         float scale_factor = (gContext.mViewMat.m16)[0];
+         float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates) / scale_factor;
+         float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates)/ scale_factor;
 
-         float lenDirPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneX, localCoordinates);
-         float lenDirMinusPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneX, localCoordinates);
+         float lenDirPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneX, localCoordinates)/ scale_factor;
+         float lenDirMinusPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneX, localCoordinates)/ scale_factor;
 
-         float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY, localCoordinates);
-         float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY, localCoordinates);
+         float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY, localCoordinates)/ scale_factor;
+         float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY, localCoordinates)/ scale_factor;
 
          std::cout << lenDir << " " << lenDirMinus << " " << lenDirPlaneX << " " << lenDirMinusPlaneX << " " << lenDirPlaneY << " " << lenDirMinusPlaneY << std::endl;
 

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2065,6 +2065,12 @@ namespace IMGUIZMO_NAMESPACE
 
          const float dx = dirPlaneX.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
          const float dy = dirPlaneY.Dot3((posOnPlan - gContext.mModel.v.position) * (1.f / gContext.mScreenFactor));
+         
+         std::cout << dirPlaneX.x << " " << dirPlaneX.y << " " << dirPlaneX.z << std::endl;
+         std::cout << dirPlaneY.x << " " << dirPlaneY.y << " " << dirPlaneY.z << std::endl;
+         std::cout <<(posOnPlan - gContext.mModel.v.position).x << " " << (posOnPlan - gContext.mModel.v.position).y << " " << (posOnPlan - gContext.mModel.v.position).z << std::endl;
+         std::cout << dx << " " << dy << std::endl << "---------" << std::endl;
+
          if (belowPlaneLimit && dx >= quadUV[0] && dx <= quadUV[4] && dy >= quadUV[1] && dy <= quadUV[3] && Contains(op, TRANSLATE_PLANS[i]))
          {
             type = MT_MOVE_YZ + i;

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1151,25 +1151,25 @@ namespace IMGUIZMO_NAMESPACE
       {
          // new method
          float scale_factor = (gContext.mViewMat.m16)[0];
-         float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates) / scale_factor;
-         float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates)/ scale_factor;
+         float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates);
+         float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates);
 
-         float lenDirPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneX, localCoordinates)/ scale_factor;
-         float lenDirMinusPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneX, localCoordinates)/ scale_factor;
+         float lenDirPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneX, localCoordinates);
+         float lenDirMinusPlaneX = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneX, localCoordinates);
 
-         float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY, localCoordinates)/ scale_factor;
-         float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY, localCoordinates)/ scale_factor;
-
-         std::cout << lenDir << " " << lenDirMinus << " " << lenDirPlaneX << " " << lenDirMinusPlaneX << " " << lenDirPlaneY << " " << lenDirMinusPlaneY << std::endl;
+         float lenDirPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirPlaneY, localCoordinates);
+         float lenDirMinusPlaneY = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirPlaneY, localCoordinates);
 
          // For readability
          bool & allowFlip = gContext.mAllowAxisFlip;
          float mulAxis = (allowFlip && lenDir < lenDirMinus&& fabsf(lenDir - lenDirMinus) > FLT_EPSILON) ? -1.f : 1.f;
          float mulAxisX = (allowFlip && lenDirPlaneX < lenDirMinusPlaneX&& fabsf(lenDirPlaneX - lenDirMinusPlaneX) > FLT_EPSILON) ? -1.f : 1.f;
          float mulAxisY = (allowFlip && lenDirPlaneY < lenDirMinusPlaneY&& fabsf(lenDirPlaneY - lenDirMinusPlaneY) > FLT_EPSILON) ? -1.f : 1.f;
-         dirAxis *= mulAxis;
-         dirPlaneX *= mulAxisX;
-         dirPlaneY *= mulAxisY;
+         dirAxis *= mulAxis / scale_factor;
+         dirPlaneX *= mulAxisX / scale_factor;
+         dirPlaneY *= mulAxisY / scale_factor;
+
+         std::cout << gContext.mScreenFactor << std::endl;
 
          // for axis
          float axisLengthInClipSpace = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis * gContext.mScreenFactor, localCoordinates);

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1150,7 +1150,7 @@ namespace IMGUIZMO_NAMESPACE
       else
       {
          // new method
-         float scale_factor = (gContext.mViewMat.m16)[0];
+         float scale_factor = std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 0], std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 1], (gContext.mViewMat.m16)[axisIndex * 4 + 2]));
          float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates);
          float lenDirMinus = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), -dirAxis, localCoordinates);
 

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1153,7 +1153,7 @@ namespace IMGUIZMO_NAMESPACE
          float scale_factor = 1.0f;
          if (constancy == DISPLAY_CONST)
          {
-            float scale_factor = std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 0], std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 1], (gContext.mViewMat.m16)[axisIndex * 4 + 2]));
+            scale_factor = std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 0], std::hypot((gContext.mViewMat.m16)[axisIndex * 4 + 1], (gContext.mViewMat.m16)[axisIndex * 4 + 2]));
          }
 
          float lenDir = GetSegmentLengthClipSpace(makeVect(0.f, 0.f, 0.f), dirAxis, localCoordinates);

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -779,9 +779,9 @@ namespace IMGUIZMO_NAMESPACE
 
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    //
-   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion);
-   static int GetRotateType(OPERATION op);
-   static int GetScaleType(OPERATION op);
+   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion, CONSTANCY constancy = SCALE_CONST);
+   static int GetRotateType(OPERATION op, CONSTANCY constancy = SCALE_CONST);
+   static int GetScaleType(OPERATION op, CONSTANCY constancy = SCALE_CONST);
 
    Style& GetStyle()
    {
@@ -987,28 +987,28 @@ namespace IMGUIZMO_NAMESPACE
       return (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID)) || gContext.mbUsingBounds;
    }
 
-   bool IsOver()
+   bool IsOver(CONSTANCY constancy = SCALE_CONST)
    {
-      return (Intersects(gContext.mOperation, TRANSLATE) && GetMoveType(gContext.mOperation, NULL) != MT_NONE) ||
-         (Intersects(gContext.mOperation, ROTATE) && GetRotateType(gContext.mOperation) != MT_NONE) ||
-         (Intersects(gContext.mOperation, SCALE) && GetScaleType(gContext.mOperation) != MT_NONE) || IsUsing();
+      return (Intersects(gContext.mOperation, TRANSLATE) && GetMoveType(gContext.mOperation, NULL, constancy) != MT_NONE) ||
+         (Intersects(gContext.mOperation, ROTATE) && GetRotateType(gContext.mOperation, constancy) != MT_NONE) ||
+         (Intersects(gContext.mOperation, SCALE) && GetScaleType(gContext.mOperation, constancy) != MT_NONE) || IsUsing();
    }
 
-   bool IsOver(OPERATION op)
+   bool IsOver(OPERATION op, CONSTANCY constancy = SCALE_CONST)
    {
       if(IsUsing())
       {
          return true;
       }
-      if(Intersects(op, SCALE) && GetScaleType(op) != MT_NONE)
+      if(Intersects(op, SCALE) && GetScaleType(op, constancy) != MT_NONE)
       {
          return true;
       }
-      if(Intersects(op, ROTATE) && GetRotateType(op) != MT_NONE)
+      if(Intersects(op, ROTATE) && GetRotateType(op, constancy) != MT_NONE)
       {
          return true;
       }
-      if(Intersects(op, TRANSLATE) && GetMoveType(op, NULL) != MT_NONE)
+      if(Intersects(op, TRANSLATE) && GetMoveType(op, NULL, constancy) != MT_NONE)
       {
          return true;
       }
@@ -1613,7 +1613,7 @@ namespace IMGUIZMO_NAMESPACE
       return false;
    }
 
-   static void HandleAndDrawLocalBounds(const float* bounds, matrix_t* matrix, const float* snapValues, OPERATION operation)
+   static void HandleAndDrawLocalBounds(const float* bounds, matrix_t* matrix, const float* snapValues, OPERATION operation, CONSTANCY constancy = SCALE_CONST)
    {
       ImGuiIO& io = ImGui::GetIO();
       ImDrawList* drawList = gContext.mDrawList;
@@ -1733,15 +1733,15 @@ namespace IMGUIZMO_NAMESPACE
 
             if(Intersects(operation, TRANSLATE))
             {
-               type = GetMoveType(operation, &gizmoHitProportion);
+               type = GetMoveType(operation, &gizmoHitProportion, constancy);
             }
             if(Intersects(operation, ROTATE) && type == MT_NONE)
             {
-               type = GetRotateType(operation);
+               type = GetRotateType(operation, constancy);
             }
             if(Intersects(operation, SCALE) && type == MT_NONE)
             {
-               type = GetScaleType(operation);
+               type = GetScaleType(operation, constancy);
             }
 
             if (type != MT_NONE)
@@ -1877,7 +1877,7 @@ namespace IMGUIZMO_NAMESPACE
    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
    //
 
-   static int GetScaleType(OPERATION op)
+   static int GetScaleType(OPERATION op, CONSTANCY constancy)
    {
       if (gContext.mbUsing)
       {
@@ -1903,7 +1903,7 @@ namespace IMGUIZMO_NAMESPACE
          }
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
-         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true, constancy);
          dirAxis.TransformVector(gContext.mModelLocal);
          dirPlaneX.TransformVector(gContext.mModelLocal);
          dirPlaneY.TransformVector(gContext.mModelLocal);
@@ -1943,7 +1943,7 @@ namespace IMGUIZMO_NAMESPACE
 
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
-         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true);
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, true, constancy);
 
          // draw axis
          if (belowAxisLimit)
@@ -1964,7 +1964,7 @@ namespace IMGUIZMO_NAMESPACE
       return type;
    }
 
-   static int GetRotateType(OPERATION op)
+   static int GetRotateType(OPERATION op, CONSTANCY constancy)
    {
       if (gContext.mbUsing)
       {
@@ -2022,7 +2022,7 @@ namespace IMGUIZMO_NAMESPACE
       return type;
    }
 
-   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion)
+   static int GetMoveType(OPERATION op, vec_t* gizmoHitProportion, CONSTANCY constancy)
    {
       if(!Intersects(op, TRANSLATE) || gContext.mbUsing || !gContext.mbMouseOver)
       {
@@ -2046,7 +2046,7 @@ namespace IMGUIZMO_NAMESPACE
       {
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
-         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);
+         ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit, false, constancy);
          dirAxis.TransformVector(gContext.mModel);
          dirPlaneX.TransformVector(gContext.mModel);
          dirPlaneY.TransformVector(gContext.mModel);
@@ -2078,7 +2078,7 @@ namespace IMGUIZMO_NAMESPACE
       return type;
    }
 
-   static bool HandleTranslation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
+   static bool HandleTranslation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap, CONSTANCY constancy = SCALE_CONST)
    {
       if(!Intersects(op, TRANSLATE) || type != MT_NONE)
       {
@@ -2163,7 +2163,7 @@ namespace IMGUIZMO_NAMESPACE
       {
          // find new possible way to move
          vec_t gizmoHitProportion;
-         type = GetMoveType(op, &gizmoHitProportion);
+         type = GetMoveType(op, &gizmoHitProportion, constancy);
          if (type != MT_NONE)
          {
 #if IMGUI_VERSION_NUM >= 18723
@@ -2200,7 +2200,7 @@ namespace IMGUIZMO_NAMESPACE
       return modified;
    }
 
-   static bool HandleScale(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
+   static bool HandleScale(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap, CONSTANCY constancy = SCALE_CONST)
    {
       if((!Intersects(op, SCALE) && !Intersects(op, SCALEU)) || type != MT_NONE || !gContext.mbMouseOver)
       {
@@ -2212,7 +2212,7 @@ namespace IMGUIZMO_NAMESPACE
       if (!gContext.mbUsing)
       {
          // find new possible way to scale
-         type = GetScaleType(op);
+         type = GetScaleType(op, constancy);
          if (type != MT_NONE)
          {
 #if IMGUI_VERSION_NUM >= 18723
@@ -2321,7 +2321,7 @@ namespace IMGUIZMO_NAMESPACE
       return modified;
    }
 
-   static bool HandleRotation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap)
+   static bool HandleRotation(float* matrix, float* deltaMatrix, OPERATION op, int& type, const float* snap, CONSTANCY constancy = SCALE_CONST)
    {
       if(!Intersects(op, ROTATE) || type != MT_NONE || !gContext.mbMouseOver)
       {
@@ -2333,7 +2333,7 @@ namespace IMGUIZMO_NAMESPACE
 
       if (!gContext.mbUsing)
       {
-         type = GetRotateType(op);
+         type = GetRotateType(op, constancy);
 
          if (type != MT_NONE)
          {
@@ -2515,15 +2515,15 @@ namespace IMGUIZMO_NAMESPACE
       {
          if (!gContext.mbUsingBounds)
          {
-            manipulated = HandleTranslation(matrix, deltaMatrix, operation, type, snap) ||
-                          HandleScale(matrix, deltaMatrix, operation, type, snap) ||
-                          HandleRotation(matrix, deltaMatrix, operation, type, snap);
+            manipulated = HandleTranslation(matrix, deltaMatrix, operation, type, snap, constancy) ||
+                          HandleScale(matrix, deltaMatrix, operation, type, snap, constancy) ||
+                          HandleRotation(matrix, deltaMatrix, operation, type, snap, constancy);
          }
       }
 
       if (localBounds && !gContext.mbUsing)
       {
-         HandleAndDrawLocalBounds(localBounds, (matrix_t*)matrix, boundsSnap, operation);
+         HandleAndDrawLocalBounds(localBounds, (matrix_t*)matrix, boundsSnap, operation, constancy);
       }
 
       gContext.mOperation = operation;

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -202,7 +202,13 @@ namespace IMGUIZMO_NAMESPACE
       WORLD
    };
 
-   IMGUI_API bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix = NULL, const float* snap = NULL, const float* localBounds = NULL, const float* boundsSnap = NULL);
+   enum CONSTANCY
+   {
+      SCALE_CONST = (1u << 0),
+      DISPLAY_CONST
+   };
+
+   IMGUI_API bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix = NULL, const float* snap = NULL, const float* localBounds = NULL, const float* boundsSnap = NULL, CONSTANCY constancy = SCALE_CONST);
    //
    // Please note that this cubeview is patented by Autodesk : https://patents.google.com/patent/US7782319B2/en
    // It seems to be a defensive patent in the US. I don't think it will bring troubles using it as


### PR DESCRIPTION
Background: I'm working on an engine involving manipulating stuffs across real-world semantic maps. Since the map is really large (and the unit length of the engine is different from industrial game engines like UE or unity), sometimes when I zoom out and intend to move something, the arrow/moving plane will shrink until invisible, which makes it impossible to move things around. Same thing happens when translation values become really large (say, 10,000).

Solution: I added up an option, CONSTANCY, which indicates the display mode of gizmo itself. When it's set to SCALE_CONST, the arrow length and plane length will remain world-space constant (becoming larger/smaller when zooming in or not), and it's the default value for added argument - which means that no modification required for existing codes. When it's set to DISPLAY_CONST however, the arrow/plane will remain screen-space constant (no change when zooming in or out).

TODOs: I've done most works for translation and scaling. Rotation is still WIP.