### PR TITLE
Fix issue with calculating segment clip length with aspect ratio < 1.0

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -845,7 +845,10 @@ namespace IMGUIZMO_NAMESPACE
       }
 
       vec_t clipSpaceAxis = endOfSegment - startOfSegment;
-      clipSpaceAxis.y /= gContext.mDisplayRatio;
+      if (gContext.mDisplayRatio < 1.0)
+         clipSpaceAxis.x *= gContext.mDisplayRatio;
+      else
+         clipSpaceAxis.y /= gContext.mDisplayRatio;
       float segmentLengthInClipSpace = sqrtf(clipSpaceAxis.x * clipSpaceAxis.x + clipSpaceAxis.y * clipSpaceAxis.y);
       return segmentLengthInClipSpace;
    }


### PR DESCRIPTION
Hello,
first of all thanks for making such a nice manipulator library for ImGui.
I've recently started using it in my project and I hope to make some contributions.

An issue I found is with the manipulator scaling when the aspect ratio is "vertical" (height > width).
I figured it's just due to wrong handling of the aspect ratio in the GetSegmentLengthClipSpace() method and this should fix it.
I've attached vidoes to demonstrate the change. 


The **old** behaviour with the perspective matrix the demo is using. The manipulator shrinks to almost nothing when the aspect ratio < 1.0.
https://user-images.githubusercontent.com/44985061/232149374-b2b8f6fc-70f7-4947-9264-675231646ad7.mp4

The **new** behaviour, the manipulator no longer shrinks too much when the aspect ratio < 1.0.
https://user-images.githubusercontent.com/44985061/232149357-680ed1e1-3e43-4afe-98fa-a1fe33de07b6.mp4

I also tested this with just a regular perspective matrix produced by glm::perspective()
**Old**:
https://user-images.githubusercontent.com/44985061/232149385-cab5eb48-61dd-4094-997c-0b346ddd5b10.mp4
**New**:
https://user-images.githubusercontent.com/44985061/232149339-b5aae794-c02d-47e1-a219-ea78aa8dcbf9.mp4

I hope this doesn't have any adverse effects.

Also note that in the current ImGuizmo demo the perspective matrix is not updated when resizing the ImGui window. That can cause the perspective matrix's aspect ratio to be different than ImGuizmo thinks and the manipulator stretches the wrong way. Although the entire viewport is undesirably stretching. That should probably be fixed too. This fix makes the manipulator in the demo behave a little odd, but its an issue with the demo and not the fix.