### PR TITLE
Add ImGuizmo::IsUsingAny

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -990,6 +990,11 @@ namespace IMGUIZMO_NAMESPACE
    {
       return (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID)) || gContext.mbUsingBounds;
    }
+   
+   bool IsUsingAny()
+   {
+      return gContext.mbUsing || gContext.mbUsingBounds;
+   }
 
    bool IsOver()
    {

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -136,6 +136,9 @@ namespace IMGUIZMO_NAMESPACE
    // return true if mouse IsOver or if the gizmo is in moving state
    IMGUI_API bool IsUsing();
 
+   // return true if any gizmo is in moving state
+   IMGUI_API bool IsUsingAny();
+
    // enable/disable the gizmo. Stay in the state until next call to Enable.
    // gizmo is rendered with gray half transparent color when disabled
    IMGUI_API void Enable(bool enable);


### PR DESCRIPTION
After https://github.com/CedricGuillemet/ImGuizmo/pull/289 its no longer possible to know if any gizmo is active without manual tracking (for example, to prevent left-click camera movement)

This PR adds the old code back but under a new name