### PR TITLE
Added 2D support through axis masking (Issue #49)

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1276,7 +1276,7 @@ namespace IMGUIZMO_NAMESPACE
             continue;
          }
 
-         bool isAxisMasked = (1 << 2 - axis) & gContext.mAxisMask;
+         bool isAxisMasked = (1 << (2 - axis)) & gContext.mAxisMask;
 
          if ((!isAxisMasked || isMultipleAxesMasked) && !isNoAxesMasked)
          {

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1283,7 +1283,7 @@ namespace IMGUIZMO_NAMESPACE
             continue;
          }
          const bool usingAxis = (gContext.mbUsing && type == MT_ROTATE_Z - axis);
-         const int circleMul = (hasRSC && !usingAxis && (isMultipleAxesMasked || isNoAxesMasked)) ? 1 : 2;
+         const int circleMul = (hasRSC && !usingAxis) ? 1 : 2;
 
          ImVec2* circlePos = (ImVec2*)alloca(sizeof(ImVec2) * (circleMul * halfCircleSegmentCount + 1));
 
@@ -2069,10 +2069,7 @@ namespace IMGUIZMO_NAMESPACE
          io.MousePos.y >= gContext.mScreenSquareMin.y && io.MousePos.y <= gContext.mScreenSquareMax.y &&
          Contains(op, TRANSLATE))
       {
-         if (!isNoAxesMasked)
-            type = MT_MOVE_YZ + (gContext.mAxisMask >> 1);
-         else
-            type = MT_MOVE_SCREEN;
+         type = MT_MOVE_SCREEN;
       }
 
       const vec_t screenCoord = makeVect(io.MousePos - ImVec2(gContext.mX, gContext.mY));

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -229,6 +229,8 @@ namespace IMGUIZMO_NAMESPACE
 
    // Configure the limit where axis are hidden
    IMGUI_API void SetAxisLimit(float value);
+   // Set an axis mask to permanently hide a given axis (true -> hidden, false -> shown)
+   IMGUI_API void SetAxisMask(bool x, bool y, bool z);
    // Configure the limit where planes are hiden
    IMGUI_API void SetPlaneLimit(float value);
 


### PR DESCRIPTION
I added a function `void SetAxisMask(bool x, bool y, bool z)` which allows the user to permanently hide whichever axis is set to `true`, multiple axes can be hidden (although it's kind of pointless).
As suggested in Issue #49, I used the `belowAxisLimit` boolean to hide the given axes for translation and scale, for rotation, however, the `DrawRotationGizmo` function was edited in order to show the rotation widget on whichever plane is perpendicular to the masked axis (no widget is shown if 2 or more axes are masked), the same was done for plane movement with the translation gizmo. Aditionally, in the case of `MT_ROTATE_SCREEN`, it is completely removed should any axis be masked (It didn't make much sense to me to be able to rotate it in any given direction when it's supposed to be masked), however both `MT_SCALE_XYZ` and 'MT_MOVE_SCREEN' were left as is (It made more sense for these to have an "override" of sorts, but that's just personal opinion)

I'm quite new to ImGuizmo and did this for a personal project and thought it could be handy, which is why I made a pull request, but since I'm not very familiar with it I may have put the checks for masking in suboptimal places, however I believe the checks themselves are quite efficient since they consist solely of bit operations.

Keep in mind I have NOT tested this as thoroughly as I probably should have, and it may cause unforseen issues, but for my personal usecase it seems to cause no problems