### PR TITLE
Moved IMGUI_DEFINE_MATH_OPERATORS define in front of imgui.h 

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -24,10 +24,10 @@
 // SOFTWARE.
 //
 
-#include "imgui.h"
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif
+#include "imgui.h"
 #include "imgui_internal.h"
 #include "ImGuizmo.h"
 


### PR DESCRIPTION
Moved IMGUI_DEFINE_MATH_OPERATORS define in front of imgui.h  as these are now defined there.

See https://github.com/ocornut/imgui/blob/46843b683bd4311382acd4daabc59df4870b0710/imgui_internal.h#L94-L98