### PR TITLE
Add Push/Pop ID to replace SetID

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1782,7 +1782,7 @@ namespace IMGUIZMO_NAMESPACE
                gContext.mBoundsLocalPivot[thirdAxis] = aabb[oppositeIndex][thirdAxis];
 
                gContext.mbUsingBounds = true;
-               gContext.mEditingID = gContext.mIDStack.front();
+               gContext.mEditingID = gContext.GetCurrentID();
                gContext.mBoundsMatrix = gContext.mModelSource;
             }
             // small anchor on middle of segment

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -668,6 +668,7 @@ namespace IMGUIZMO_NAMESPACE
    {
       Context() : mbUsing(false), mbEnable(true), mbUsingBounds(false)
       {
+		  mIDStack.push_back(-1);
       }
 
       ImDrawList* mDrawList;
@@ -755,12 +756,14 @@ namespace IMGUIZMO_NAMESPACE
 
       bool mIsOrthographic = false;
 
-      int mActualID = -1;
-      int mEditingID = -1;
+      ImVector<ImGuiID> mIDStack;
+      ImGuiID mEditingID = -1;
       OPERATION mOperation = OPERATION(-1);
 
       bool mAllowAxisFlip = true;
       float mGizmoSizeClipSpace = 0.1f;
+
+      inline ImGuiID GetCurrentID() {return mIDStack.back();}
    };
 
    static Context gContext;
@@ -988,7 +991,7 @@ namespace IMGUIZMO_NAMESPACE
 
    bool IsUsing()
    {
-      return (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID)) || gContext.mbUsingBounds;
+      return (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID)) || gContext.mbUsingBounds;
    }
 
    bool IsUsingAny()
@@ -1146,7 +1149,7 @@ namespace IMGUIZMO_NAMESPACE
       dirPlaneX = directionUnary[(axisIndex + 1) % 3];
       dirPlaneY = directionUnary[(axisIndex + 2) % 3];
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID))
       {
          // when using, use stored factors so the gizmo doesn't flip when we translate
          belowAxisLimit = gContext.mBelowAxisLimit[axisIndex];
@@ -1298,7 +1301,7 @@ namespace IMGUIZMO_NAMESPACE
          drawList->AddCircle(worldToPos(gContext.mModel.v.position, gContext.mViewProjection), gContext.mRadiusSquareCenter, colors[0], 64, gContext.mStyle.RotationOuterLineThickness);
       }
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(type))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsRotateType(type))
       {
          ImVec2 circlePos[halfCircleSegmentCount + 1];
 
@@ -1355,7 +1358,7 @@ namespace IMGUIZMO_NAMESPACE
       // draw
       vec_t scaleDisplay = { 1.f, 1.f, 1.f, 1.f };
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID))
       {
          scaleDisplay = gContext.mScale;
       }
@@ -1382,7 +1385,7 @@ namespace IMGUIZMO_NAMESPACE
                ImVec2 worldDirSSpaceNoScale = worldToPos(dirAxis * markerScale * gContext.mScreenFactor, gContext.mMVP);
                ImVec2 worldDirSSpace = worldToPos((dirAxis * markerScale * scaleDisplay[i]) * gContext.mScreenFactor, gContext.mMVP);
 
-               if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+               if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID))
                {
                   ImU32 scaleLineColor = GetColorU32(SCALE_LINE);
                   drawList->AddLine(baseSSpace, worldDirSSpaceNoScale, scaleLineColor, gContext.mStyle.ScaleLineThickness);
@@ -1406,7 +1409,7 @@ namespace IMGUIZMO_NAMESPACE
       // draw screen cirle
       drawList->AddCircleFilled(gContext.mScreenSquareCenter, gContext.mStyle.CenterCircleSize, colors[0], 32);
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(type))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsScaleType(type))
       {
          //ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
          ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
@@ -1443,7 +1446,7 @@ namespace IMGUIZMO_NAMESPACE
       // draw
       vec_t scaleDisplay = { 1.f, 1.f, 1.f, 1.f };
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID))
       {
          scaleDisplay = gContext.mScale;
       }
@@ -1471,7 +1474,7 @@ namespace IMGUIZMO_NAMESPACE
                ImVec2 worldDirSSpace = worldToPos((dirAxis * markerScale * scaleDisplay[i]) * gContext.mScreenFactor, gContext.mMVPLocal);
 
 #if 0
-               if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+               if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID))
                {
                   drawList->AddLine(baseSSpace, worldDirSSpaceNoScale, IM_COL32(0x40, 0x40, 0x40, 0xFF), 3.f);
                   drawList->AddCircleFilled(worldDirSSpaceNoScale, 6.f, IM_COL32(0x40, 0x40, 0x40, 0xFF));
@@ -1491,7 +1494,7 @@ namespace IMGUIZMO_NAMESPACE
       // draw screen cirle
       drawList->AddCircle(gContext.mScreenSquareCenter, 20.f, colors[0], 32, gContext.mStyle.CenterCircleSize);
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(type))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsScaleType(type))
       {
          //ImVec2 sourcePosOnScreen = worldToPos(gContext.mMatrixOrigin, gContext.mViewProjection);
          ImVec2 destinationPosOnScreen = worldToPos(gContext.mModel.v.position, gContext.mViewProjection);
@@ -1585,7 +1588,7 @@ namespace IMGUIZMO_NAMESPACE
 
       drawList->AddCircleFilled(gContext.mScreenSquareCenter, gContext.mStyle.CenterCircleSize, colors[0], 32);
 
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(type))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsTranslateType(type))
       {
          ImU32 translationLineColor = GetColorU32(TRANSLATION_LINE);
 
@@ -1779,7 +1782,7 @@ namespace IMGUIZMO_NAMESPACE
                gContext.mBoundsLocalPivot[thirdAxis] = aabb[oppositeIndex][thirdAxis];
 
                gContext.mbUsingBounds = true;
-               gContext.mEditingID = gContext.mActualID;
+               gContext.mEditingID = gContext.mIDStack.front();
                gContext.mBoundsMatrix = gContext.mModelSource;
             }
             // small anchor on middle of segment
@@ -1798,12 +1801,12 @@ namespace IMGUIZMO_NAMESPACE
                gContext.mBoundsLocalPivot[gContext.mBoundsAxis[0]] = aabb[oppositeIndex][indices[i % 2]];// bounds[gContext.mBoundsAxis[0]] * (((i + 1) & 2) ? 1.f : -1.f);
 
                gContext.mbUsingBounds = true;
-               gContext.mEditingID = gContext.mActualID;
+               gContext.mEditingID = gContext.GetCurrentID();
                gContext.mBoundsMatrix = gContext.mModelSource;
             }
          }
 
-         if (gContext.mbUsingBounds && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID))
+         if (gContext.mbUsingBounds && (gContext.GetCurrentID() == gContext.mEditingID))
          {
             matrix_t scale;
             scale.SetToIdentity();
@@ -2092,7 +2095,7 @@ namespace IMGUIZMO_NAMESPACE
       bool modified = false;
 
       // move
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsTranslateType(gContext.mCurrentOperation))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsTranslateType(gContext.mCurrentOperation))
       {
 #if IMGUI_VERSION_NUM >= 18723
          ImGui::SetNextFrameWantCaptureMouse(true);
@@ -2178,7 +2181,7 @@ namespace IMGUIZMO_NAMESPACE
          if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
-            gContext.mEditingID = gContext.mActualID;
+            gContext.mEditingID = gContext.GetCurrentID();
             gContext.mCurrentOperation = type;
             vec_t movePlanNormal[] = { gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir,
                gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir,
@@ -2227,7 +2230,7 @@ namespace IMGUIZMO_NAMESPACE
          if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
-            gContext.mEditingID = gContext.mActualID;
+            gContext.mEditingID = gContext.GetCurrentID();
             gContext.mCurrentOperation = type;
             const vec_t movePlanNormal[] = { gContext.mModel.v.up, gContext.mModel.v.dir, gContext.mModel.v.right, gContext.mModel.v.dir, gContext.mModel.v.up, gContext.mModel.v.right, -gContext.mCameraDir };
             // pickup plan
@@ -2243,7 +2246,7 @@ namespace IMGUIZMO_NAMESPACE
          }
       }
       // scale
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsScaleType(gContext.mCurrentOperation))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsScaleType(gContext.mCurrentOperation))
       {
 #if IMGUI_VERSION_NUM >= 18723
          ImGui::SetNextFrameWantCaptureMouse(true);
@@ -2355,7 +2358,7 @@ namespace IMGUIZMO_NAMESPACE
          if (CanActivate() && type != MT_NONE)
          {
             gContext.mbUsing = true;
-            gContext.mEditingID = gContext.mActualID;
+            gContext.mEditingID = gContext.GetCurrentID();
             gContext.mCurrentOperation = type;
             const vec_t rotatePlanNormal[] = { gContext.mModel.v.right, gContext.mModel.v.up, gContext.mModel.v.dir, -gContext.mCameraDir };
             // pickup plan
@@ -2376,7 +2379,7 @@ namespace IMGUIZMO_NAMESPACE
       }
 
       // rotation
-      if (gContext.mbUsing && (gContext.mActualID == -1 || gContext.mActualID == gContext.mEditingID) && IsRotateType(gContext.mCurrentOperation))
+      if (gContext.mbUsing && (gContext.GetCurrentID() == gContext.mEditingID) && IsRotateType(gContext.mCurrentOperation))
       {
 #if IMGUI_VERSION_NUM >= 18723
          ImGui::SetNextFrameWantCaptureMouse(true);
@@ -2484,7 +2487,63 @@ namespace IMGUIZMO_NAMESPACE
 
    void SetID(int id)
    {
-      gContext.mActualID = id;
+      gContext.mIDStack.back() = id;
+   }
+
+   ImGuiID GetID(const char* str, const char* str_end)
+   {
+      ImGuiID seed = gContext.mIDStack.back();
+      ImGuiID id = ImHashStr(str, str_end ? (str_end - str) : 0, seed);
+      return id;
+   }
+
+   ImGuiID GetID(const char* str)
+   {
+      return GetID(str, nullptr);
+   }
+
+   ImGuiID GetID(const void* ptr)
+   {
+      ImGuiID seed = gContext.mIDStack.back();
+      ImGuiID id = ImHashData(&ptr, sizeof(void*), seed);
+      return id;
+   }
+
+   ImGuiID GetID(int n)
+   {
+      ImGuiID seed = gContext.mIDStack.back();
+      ImGuiID id = ImHashData(&n, sizeof(n), seed);
+      return id;
+   }
+
+   void PushID(const char* str_id)
+   {
+      ImGuiID id = GetID(str_id);
+      gContext.mIDStack.push_back(id);
+   }
+
+   void PushID(const char* str_id_begin, const char* str_id_end)
+   {
+      ImGuiID id = GetID(str_id_begin, str_id_end);
+      gContext.mIDStack.push_back(id);
+   }
+
+   void PushID(const void* ptr_id)
+   {
+      ImGuiID id = GetID(ptr_id);
+      gContext.mIDStack.push_back(id);
+   }
+
+   void PushID(int int_id)
+   {
+      ImGuiID id = GetID(int_id);
+      gContext.mIDStack.push_back(id);
+   }
+
+   void PopID()
+   {
+      IM_ASSERT(gContext.mIDStack.Size > 1); // Too many PopID(), or could be popping in a wrong/different window?
+      gContext.mIDStack.pop_back();
    }
 
    void AllowAxisFlip(bool value)

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -216,7 +216,28 @@ namespace IMGUIZMO_NAMESPACE
    // use this version if you did not call Manipulate before and you are just using ViewManipulate
    IMGUI_API void ViewManipulate(float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
 
+   [[deprecated("Use PushID/PopID instead.")]]
    IMGUI_API void SetID(int id);
+
+	// ID stack/scopes
+	// Read the FAQ (docs/FAQ.md or http://dearimgui.org/faq) for more details about how ID are handled in dear imgui.
+	// - Those questions are answered and impacted by understanding of the ID stack system:
+	//   - "Q: Why is my widget not reacting when I click on it?"
+	//   - "Q: How can I have widgets with an empty label?"
+	//   - "Q: How can I have multiple widgets with the same label?"
+	// - Short version: ID are hashes of the entire ID stack. If you are creating widgets in a loop you most likely
+	//   want to push a unique identifier (e.g. object pointer, loop index) to uniquely differentiate them.
+	// - You can also use the "Label##foobar" syntax within widget label to distinguish them from each others.
+	// - In this header file we use the "label"/"name" terminology to denote a string that will be displayed + used as an ID,
+	//   whereas "str_id" denote a string that is only used as an ID and not normally displayed.
+	IMGUI_API void          PushID(const char* str_id);                                     // push string into the ID stack (will hash string).
+	IMGUI_API void          PushID(const char* str_id_begin, const char* str_id_end);       // push string into the ID stack (will hash string).
+	IMGUI_API void          PushID(const void* ptr_id);                                     // push pointer into the ID stack (will hash pointer).
+	IMGUI_API void          PushID(int int_id);                                             // push integer into the ID stack (will hash integer).
+	IMGUI_API void          PopID();                                                        // pop from the ID stack.
+	IMGUI_API ImGuiID       GetID(const char* str_id);                                      // calculate unique ID (hash of whole ID stack + given parameter). e.g. if you want to query into ImGuiStorage yourself
+	IMGUI_API ImGuiID       GetID(const char* str_id_begin, const char* str_id_end);
+	IMGUI_API ImGuiID       GetID(const void* ptr_id);
 
    // return true if the cursor is over the operation's gizmo
    IMGUI_API bool IsOver(OPERATION op);


### PR DESCRIPTION
I've changed the system a bit to support push/pop ID as I needed it to use in a [project ](https://github.com/Sayama3/Voxengine) I'm making.

I've reused the functions and the way IDs are handled in ImGui so that the workflow is similar.

I've tried to keep the `SetID` but marked it as deprecated as I don't think it fit the idea of ImGui.

Here is an example achieved using the IDs :

the gizmo at the center of the object don't have an ID (to keep this functionality working) and the 4 other point have IDs stacking in the following order `ObjectID -> ComponentID -> IndexOfThePointInArray`

![Gizmos_Tests](https://github.com/CedricGuillemet/ImGuizmo/assets/39456336/8cb2abb9-d2e0-44c0-9b3f-9e63b22b241a)

I thought it might be a useful feature, so I'm doing a Pull Request.