### PR TITLE
Fix issue #96

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2504,6 +2504,8 @@ namespace IMGUIZMO_NAMESPACE
 
    bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix, const float* snap, const float* localBounds, const float* boundsSnap)
    {
+      gContext.mDrawList->PushClipRect (ImVec2 (gContext.mX, gContext.mY), ImVec2 (gContext.mX + gContext.mWidth, gContext.mY + gContext.mHeight), false);
+
       // Scale is always local or matrix will be skewed when applying world scale or oriented matrix
       ComputeContext(view, projection, matrix, (operation & SCALE) ? LOCAL : mode);
 
@@ -2547,6 +2549,8 @@ namespace IMGUIZMO_NAMESPACE
          DrawScaleGizmo(operation, type);
          DrawScaleUniveralGizmo(operation, type);
       }
+
+      gContext.mDrawList->PopClipRect ();
       return manipulated;
    }
 


### PR DESCRIPTION
Fix #96.

I encountered the same problem as @SaltyLeung . According to the behavior I understand, `void SetRect(float x, float y, float width, float height)` should set a rectangle on the screen in which to draw the control elements.  It can be understood that outside the specified rectangle, drawing should not be allowed.  However, the control elements are also drawn outside.

I solved this problem as recommended.

