### PR TITLE
Fixed EditTransform drawing [gizmo count] times in example/main.cpp

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -201,112 +201,97 @@ inline void rotationY(const float angle, float* m16)
    m16[15] = 1.0f;
 }
 
-void EditTransform(float* cameraView, float* cameraProjection, float* matrix, bool editTransformDecomposition)
+void TransformStart(float* cameraView, float* cameraProjection, float* matrix)
 {
-   static ImGuizmo::MODE mCurrentGizmoMode(ImGuizmo::LOCAL);
-   static bool useSnap = false;
-   static float snap[3] = { 1.f, 1.f, 1.f };
-   static float bounds[] = { -0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f };
-   static float boundsSnap[] = { 0.1f, 0.1f, 0.1f };
-   static bool boundSizing = false;
-   static bool boundSizingSnap = false;
+    static float bounds[] = { -0.5f, -0.5f, -0.5f, 0.5f, 0.5f, 0.5f };
+    static float boundsSnap[] = { 0.1f, 0.1f, 0.1f };
+    static bool boundSizing = false;
+    static bool boundSizingSnap = false;
 
-   if (editTransformDecomposition)
-   {
-      if (ImGui::IsKeyPressed(ImGuiKey_T))
-         mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
-      if (ImGui::IsKeyPressed(ImGuiKey_E))
-         mCurrentGizmoOperation = ImGuizmo::ROTATE;
-      if (ImGui::IsKeyPressed(ImGuiKey_R)) // r Key
-         mCurrentGizmoOperation = ImGuizmo::SCALE;
-      if (ImGui::RadioButton("Translate", mCurrentGizmoOperation == ImGuizmo::TRANSLATE))
-         mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
-      ImGui::SameLine();
-      if (ImGui::RadioButton("Rotate", mCurrentGizmoOperation == ImGuizmo::ROTATE))
-         mCurrentGizmoOperation = ImGuizmo::ROTATE;
-      ImGui::SameLine();
-      if (ImGui::RadioButton("Scale", mCurrentGizmoOperation == ImGuizmo::SCALE))
-         mCurrentGizmoOperation = ImGuizmo::SCALE;
-      if (ImGui::RadioButton("Universal", mCurrentGizmoOperation == ImGuizmo::UNIVERSAL))
-         mCurrentGizmoOperation = ImGuizmo::UNIVERSAL;
-      float matrixTranslation[3], matrixRotation[3], matrixScale[3];
-      ImGuizmo::DecomposeMatrixToComponents(matrix, matrixTranslation, matrixRotation, matrixScale);
-      ImGui::InputFloat3("Tr", matrixTranslation);
-      ImGui::InputFloat3("Rt", matrixRotation);
-      ImGui::InputFloat3("Sc", matrixScale);
-      ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, matrix);
+    if (ImGui::IsKeyPressed(ImGuiKey_T))
+        mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+    if (ImGui::IsKeyPressed(ImGuiKey_E))
+        mCurrentGizmoOperation = ImGuizmo::ROTATE;
+    if (ImGui::IsKeyPressed(ImGuiKey_R)) // r Key
+        mCurrentGizmoOperation = ImGuizmo::SCALE;
+    if (ImGui::RadioButton("Translate", mCurrentGizmoOperation == ImGuizmo::TRANSLATE))
+        mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Rotate", mCurrentGizmoOperation == ImGuizmo::ROTATE))
+        mCurrentGizmoOperation = ImGuizmo::ROTATE;
+    ImGui::SameLine();
+    if (ImGui::RadioButton("Scale", mCurrentGizmoOperation == ImGuizmo::SCALE))
+        mCurrentGizmoOperation = ImGuizmo::SCALE;
+    float matrixTranslation[3], matrixRotation[3], matrixScale[3];
+    ImGuizmo::DecomposeMatrixToComponents(matrix, matrixTranslation, matrixRotation, matrixScale);
+    ImGui::InputFloat3("Tr", matrixTranslation);
+    ImGui::InputFloat3("Rt", matrixRotation);
+    ImGui::InputFloat3("Sc", matrixScale);
+    ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, matrix);
 
-      if (mCurrentGizmoOperation != ImGuizmo::SCALE)
-      {
-         if (ImGui::RadioButton("Local", mCurrentGizmoMode == ImGuizmo::LOCAL))
+    if (mCurrentGizmoOperation != ImGuizmo::SCALE)
+    {
+        if (ImGui::RadioButton("Local", mCurrentGizmoMode == ImGuizmo::LOCAL))
             mCurrentGizmoMode = ImGuizmo::LOCAL;
-         ImGui::SameLine();
-         if (ImGui::RadioButton("World", mCurrentGizmoMode == ImGuizmo::WORLD))
+        ImGui::SameLine();
+        if (ImGui::RadioButton("World", mCurrentGizmoMode == ImGuizmo::WORLD))
             mCurrentGizmoMode = ImGuizmo::WORLD;
-      }
-      if (ImGui::IsKeyPressed(ImGuiKey_S))
-         useSnap = !useSnap;
-      ImGui::Checkbox("##UseSnap", &useSnap);
-      ImGui::SameLine();
+    }
+    static bool useSnap(false);
+    if (ImGui::IsKeyPressed(ImGuiKey_S))
+        useSnap = !useSnap;
+    ImGui::Checkbox(" ", &useSnap);
+    ImGui::SameLine();
+    static float snap[3] = { 1.f, 1.f, 1.f };
+    switch (mCurrentGizmoOperation)
+    {
+    case ImGuizmo::TRANSLATE:
+        ImGui::InputFloat3("Snap", &snap[0]);
+        break;
+    case ImGuizmo::ROTATE:
+        ImGui::InputFloat("Angle Snap", &snap[0]);
+        break;
+    case ImGuizmo::SCALE:
+        ImGui::InputFloat("Scale Snap", &snap[0]);
+        break;
+    }
 
-      switch (mCurrentGizmoOperation)
-      {
-      case ImGuizmo::TRANSLATE:
-         ImGui::InputFloat3("Snap", &snap[0]);
-         break;
-      case ImGuizmo::ROTATE:
-         ImGui::InputFloat("Angle Snap", &snap[0]);
-         break;
-      case ImGuizmo::SCALE:
-         ImGui::InputFloat("Scale Snap", &snap[0]);
-         break;
-      }
-      ImGui::Checkbox("Bound Sizing", &boundSizing);
-      if (boundSizing)
-      {
-         ImGui::PushID(3);
-         ImGui::Checkbox("##BoundSizing", &boundSizingSnap);
-         ImGui::SameLine();
-         ImGui::InputFloat3("Snap", boundsSnap);
-         ImGui::PopID();
-      }
-   }
+    ImGuiIO& io = ImGui::GetIO();
+    float viewManipulateRight = io.DisplaySize.x;
+    float viewManipulateTop = 0;
+    static ImGuiWindowFlags gizmoWindowFlags = 0;
+    ImGui::SetNextWindowSize(ImVec2(800, 400), ImGuiCond_Appearing);
+    ImGui::SetNextWindowPos(ImVec2(400, 20), ImGuiCond_Appearing);
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, (ImVec4)ImColor(0.35f, 0.3f, 0.3f));
+    ImGui::Begin("Gizmo", 0, gizmoWindowFlags);
+    ImGuizmo::SetDrawlist();
+    float windowWidth = (float)ImGui::GetWindowWidth();
+    float windowHeight = (float)ImGui::GetWindowHeight();
+    ImGuizmo::SetRect(ImGui::GetWindowPos().x, ImGui::GetWindowPos().y, windowWidth, windowHeight);
+    viewManipulateRight = ImGui::GetWindowPos().x + windowWidth;
+    viewManipulateTop = ImGui::GetWindowPos().y;
+    ImGuiWindow* window = ImGui::GetCurrentWindow();
+    gizmoWindowFlags = ImGui::IsWindowHovered() && ImGui::IsMouseHoveringRect(window->InnerRect.Min, window->InnerRect.Max) ? ImGuiWindowFlags_NoMove : 0;
 
-   ImGuiIO& io = ImGui::GetIO();
-   float viewManipulateRight = io.DisplaySize.x;
-   float viewManipulateTop = 0;
-   static ImGuiWindowFlags gizmoWindowFlags = 0;
-   if (useWindow)
-   {
-      ImGui::SetNextWindowSize(ImVec2(800, 400), ImGuiCond_Appearing);
-      ImGui::SetNextWindowPos(ImVec2(400,20), ImGuiCond_Appearing);
-      ImGui::PushStyleColor(ImGuiCol_WindowBg, (ImVec4)ImColor(0.35f, 0.3f, 0.3f));
-      ImGui::Begin("Gizmo", 0, gizmoWindowFlags);
-      ImGuizmo::SetDrawlist();
-      float windowWidth = (float)ImGui::GetWindowWidth();
-      float windowHeight = (float)ImGui::GetWindowHeight();
-      ImGuizmo::SetRect(ImGui::GetWindowPos().x, ImGui::GetWindowPos().y, windowWidth, windowHeight);
-      viewManipulateRight = ImGui::GetWindowPos().x + windowWidth;
-      viewManipulateTop = ImGui::GetWindowPos().y;
-      ImGuiWindow* window = ImGui::GetCurrentWindow();
-      gizmoWindowFlags = ImGui::IsWindowHovered() && ImGui::IsMouseHoveringRect(window->InnerRect.Min, window->InnerRect.Max) ? ImGuiWindowFlags_NoMove : 0;
-   }
-   else
-   {
-      ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
-   }
+    ImGuizmo::DrawGrid(cameraView, cameraProjection, identityMatrix, 100.f);
+    ImGuizmo::DrawCubes(cameraView, cameraProjection, &objectMatrix[0][0], gizmoCount);
 
-   ImGuizmo::DrawGrid(cameraView, cameraProjection, identityMatrix, 100.f);
-   ImGuizmo::DrawCubes(cameraView, cameraProjection, &objectMatrix[0][0], gizmoCount);
-   ImGuizmo::Manipulate(cameraView, cameraProjection, mCurrentGizmoOperation, mCurrentGizmoMode, matrix, NULL, useSnap ? &snap[0] : NULL, boundSizing ? bounds : NULL, boundSizingSnap ? boundsSnap : NULL);
+    ImGuizmo::ViewManipulate(cameraView, camDistance, ImVec2(viewManipulateRight - 128, viewManipulateTop), ImVec2(128, 128), 0x10101010);
+}
 
-   ImGuizmo::ViewManipulate(cameraView, camDistance, ImVec2(viewManipulateRight - 128, viewManipulateTop), ImVec2(128, 128), 0x10101010);
+void TransformEnd()
+{
+    ImGui::End();
+    ImGui::PopStyleColor(1);
+}
 
-   if (useWindow)
-   {
-      ImGui::End();
-      ImGui::PopStyleColor(1);
-   }
+void EditTransform(float* cameraView, float* cameraProjection, float* matrix)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    float windowWidth = (float)ImGui::GetWindowWidth();
+    float windowHeight = (float)ImGui::GetWindowHeight();
+    ImGuizmo::SetRect(ImGui::GetWindowPos().x, ImGui::GetWindowPos().y, windowWidth, windowHeight);
+    ImGuizmo::Manipulate(cameraView, cameraProjection, mCurrentGizmoOperation, mCurrentGizmoMode, matrix, NULL, useSnap ? &snap[0] : NULL);
 }
 
 //
@@ -811,16 +796,19 @@ int main(int, char**)
          ImGui::Text(ImGuizmo::IsOver(ImGuizmo::SCALE) ? "Over scale gizmo" : "");
       }
       ImGui::Separator();
+      
+      TransformStart(cameraView, cameraProjection, objectMatrix[lastUsing]);
       for (int matId = 0; matId < gizmoCount; matId++)
       {
-         ImGuizmo::SetID(matId);
-
-         EditTransform(cameraView, cameraProjection, objectMatrix[matId], lastUsing == matId);
-         if (ImGuizmo::IsUsing())
-         {
-            lastUsing = matId;
-         }
+          ImGuizmo::SetID(matId);
+      
+          EditTransform(cameraView, cameraProjection, objectMatrix[matId]);
+          if (ImGuizmo::IsUsing())
+          {
+              lastUsing = matId;
+          }
       }
+      TransformEnd();
 
       ImGui::End();
 


### PR DESCRIPTION
The current implementation in example/main.cpp calls the EditTransform function [gizmo count] times, to draw the gizmo on multiple objects. 
However, this approach also results in the grid, cubes, and view manipulation being drawn multiple times, which is redundant and inefficient.

The EditTransform function is intended to draw only the gizmo, as indicated in the Readme.md. 
However, in its current state, it also includes the drawing of the grid, cubes, and view manipulation.

I have refactored the code by separating the concerns within the EditTransform function.
I separated them into 2 functions, so that we only draw the rest once, and draw the gizmo on each object.