### PR TITLE
Fixes for using BeginChildFrame() obsoleted in v1.90

### DIFF
--- a/GraphEditor.cpp
+++ b/GraphEditor.cpp
@@ -837,7 +837,7 @@ void Show(Delegate& delegate, const Options& options, ViewState& viewState, bool
     captureOffset = viewState.mPosition * viewState.mFactor;
 
     //ImGui::InvisibleButton("GraphEditorButton", canvasSize);
-    ImGui::BeginChildFrame(71711, canvasSize);
+    ImGui::BeginChild(71711, canvasSize, ImGuiChildFlags_FrameStyle);
 
     ImGui::SetCursorPos(windowPos);
     ImGui::BeginGroup();
@@ -1030,7 +1030,7 @@ void Show(Delegate& delegate, const Options& options, ViewState& viewState, bool
     ImGui::PopStyleColor(1);
     ImGui::PopStyleVar(2);
     ImGui::EndGroup();
-    ImGui::EndChildFrame();
+    ImGui::EndChild();
 
     ImGui::PopStyleVar(3);
     

--- a/ImCurveEdit.cpp
+++ b/ImCurveEdit.cpp
@@ -148,7 +148,7 @@ namespace ImCurveEdit
       ImGuiIO& io = ImGui::GetIO();
       ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
       ImGui::PushStyleColor(ImGuiCol_Border, 0);
-      ImGui::BeginChildFrame(id, size);
+      ImGui::BeginChild(id, size, ImGuiChildFlags_FrameStyle);
       delegate.focused = ImGui::IsWindowFocused();
       ImDrawList* draw_list = ImGui::GetWindowDrawList();
       if (clippingRect)
@@ -441,7 +441,7 @@ namespace ImCurveEdit
       if (clippingRect)
          draw_list->PopClipRect();
 
-      ImGui::EndChildFrame();
+      ImGui::EndChild();
       ImGui::PopStyleVar();
       ImGui::PopStyleColor(1);
 

--- a/ImGradient.cpp
+++ b/ImGradient.cpp
@@ -67,7 +67,7 @@ namespace ImGradient
       bool ret = false;
       ImGuiIO& io = ImGui::GetIO();
       ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-      ImGui::BeginChildFrame(137, size);
+      ImGui::BeginChild(137, size, ImGuiChildFlags_FrameStyle);
 
       ImDrawList* draw_list = ImGui::GetWindowDrawList();
       const ImVec2 offset = ImGui::GetCursorScreenPos();
@@ -107,7 +107,7 @@ namespace ImGradient
          delegate.AddPoint(delegate.GetPoint(t));
          ret = true;
       }
-      ImGui::EndChildFrame();
+      ImGui::EndChild();
       ImGui::PopStyleVar();
 
       selection = currentSelection;

--- a/ImSequencer.cpp
+++ b/ImSequencer.cpp
@@ -162,7 +162,7 @@ namespace ImSequencer
          ImVec2 childFramePos = ImGui::GetCursorScreenPos();
          ImVec2 childFrameSize(canvas_size.x, canvas_size.y - 8.f - headerSize.y - (hasScrollBar ? scrollBarSize.y : 0));
          ImGui::PushStyleColor(ImGuiCol_FrameBg, 0);
-         ImGui::BeginChildFrame(889, childFrameSize);
+         ImGui::BeginChild(889, childFrameSize, ImGuiChildFlags_FrameStyle);
          sequence->focused = ImGui::IsWindowFocused();
          ImGui::InvisibleButton("contentBar", ImVec2(canvas_size.x, float(controlHeight)));
          const ImVec2 contentMin = ImGui::GetItemRectMin();
@@ -511,7 +511,7 @@ namespace ImSequencer
          }
          //
 
-         ImGui::EndChildFrame();
+         ImGui::EndChild();
          ImGui::PopStyleColor();
          if (hasScrollBar)
          {


### PR DESCRIPTION
This allows compiling with dear imgui with `IMGUI_DISABLE_OBSOLETE_FUNCTIONS`.
This will requires 1.90+ (released Nov 2023):
Ref: https://github.com/ocornut/imgui/commit/cdbc21a191e4d3622881ed9d9da29e3a463f0a35

If you wish to support versions of dear imgui older than 1.90 with latest ImGuizmo, you can add:
```cpp
#if IMGUI_VERSION_NUM < 18998
   ImGui::BeginChildFrame(id, size);
#else
   ImGui::BeginChild(id, size, ImGuiChildFlags_FrameStyle);
#endif
```
On the eight modified lines.
