### PR TITLE
Add IsViewManipulateHovered()

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -666,7 +666,7 @@ namespace IMGUIZMO_NAMESPACE
 
    struct Context
    {
-      Context() : mbUsing(false), mbUsingViewManipulate(false), mbEnable(true), mbUsingBounds(false)
+      Context() : mbUsing(false), mbUsingViewManipulate(false), mbEnable(true), mbUsingBounds(false), mIsViewManipulatorHovered(false)
       {
 		  mIDStack.push_back(-1);
       }
@@ -707,6 +707,7 @@ namespace IMGUIZMO_NAMESPACE
       bool mbEnable;
       bool mbMouseOver;
       bool mReversed; // reversed projection matrix
+      bool mIsViewManipulatorHovered;
 
       // translation
       vec_t mTranslationPlan;
@@ -1005,6 +1006,11 @@ namespace IMGUIZMO_NAMESPACE
    bool IsUsingViewManipulate()
    {
       return gContext.mbUsingViewManipulate;
+   }
+
+   bool IsViewManipulateHovered()
+   {
+      return gContext.mIsViewManipulatorHovered;
    }
 
    bool IsUsingAny()
@@ -2907,7 +2913,6 @@ namespace IMGUIZMO_NAMESPACE
    {
       static bool isDraging = false;
       static bool isClicking = false;
-      static bool isInside = false;
       static vec_t interpolationUp;
       static vec_t interpolationDir;
       static int interpolationFrames = 0;
@@ -3020,7 +3025,7 @@ namespace IMGUIZMO_NAMESPACE
                if (iPass)
                {
                   ImU32 directionColor = GetColorU32(DIRECTION_X + normalIndex);
-                  gContext.mDrawList->AddConvexPolyFilled(faceCoordsScreen, 4, (directionColor | IM_COL32(0x80, 0x80, 0x80, 0x80)) | (isInside ? IM_COL32(0x08, 0x08, 0x08, 0) : 0));
+                  gContext.mDrawList->AddConvexPolyFilled(faceCoordsScreen, 4, (directionColor | IM_COL32(0x80, 0x80, 0x80, 0x80)) | (gContext.mIsViewManipulatorHovered ? IM_COL32(0x08, 0x08, 0x08, 0) : 0));
                   if (boxes[boxCoordInt])
                   {
                      gContext.mDrawList->AddConvexPolyFilled(faceCoordsScreen, 4, IM_COL32(0xF0, 0xA0, 0x60, 0x80));
@@ -3049,7 +3054,7 @@ namespace IMGUIZMO_NAMESPACE
          vec_t newEye = camTarget + newDir * length;
          LookAt(&newEye.x, &camTarget.x, &newUp.x, view);
       }
-      isInside = gContext.mbMouseOver && ImRect(position, position + size).Contains(io.MousePos);
+      gContext.mIsViewManipulatorHovered = gContext.mbMouseOver && ImRect(position, position + size).Contains(io.MousePos);
 
       if (io.MouseDown[0] && (fabsf(io.MouseDelta[0]) || fabsf(io.MouseDelta[1])) && isClicking)
       {

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -39,9 +39,9 @@
 // - display rotation/translation/scale infos in local/world space and not only local
 // - finish local/world matrix application
 // - OPERATION as bitmask
-// 
+//
 // -------------------------------------------------------------------------------------------
-// Example 
+// Example
 #if 0
 void EditTransform(const Camera& camera, matrix_t& matrix)
 {
@@ -172,7 +172,7 @@ namespace IMGUIZMO_NAMESPACE
    IMGUI_API void DrawGrid(const float* view, const float* projection, const float* matrix, const float gridSize);
 
    // call it when you want a gizmo
-   // Needs view and projection matrices. 
+   // Needs view and projection matrices.
    // matrix parameter is the source matrix (where will be gizmo be drawn) and might be transformed by the function. Return deltaMatrix is optional
    // translation is applied in world space
    enum OPERATION
@@ -220,9 +220,11 @@ namespace IMGUIZMO_NAMESPACE
 
    // use this version if you did not call Manipulate before and you are just using ViewManipulate
    IMGUI_API void ViewManipulate(float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
+   // only check if your mouse is over the view manipulator
+   IMGUI_API bool IsManipulatorHovered();
 
    IMGUI_API void SetAlternativeWindow(ImGuiWindow* window);
-  
+
    [[deprecated("Use PushID/PopID instead.")]]
    IMGUI_API void SetID(int id);
 


### PR DESCRIPTION
See #322 

This helps to prevent viewport actions from being forwarded to the underlying window if you in fact clicked onto the view manipulator. The time of the first click will only set the `mbUsingViewManipulate` boolean to `true` after the imguizmo code ran - but this might be too late for applications that already executed the click for their viewport action.