### PR TITLE
Fixed div0 in ComputeContext()

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1094,7 +1094,6 @@ namespace IMGUIZMO_NAMESPACE
       // compute scale from the size of camera right vector projected on screen at the matrix position
       vec_t pointRight = viewInverse.v.right;
       pointRight.TransformPoint(gContext.mViewProjection);
-      gContext.mScreenFactor = gContext.mGizmoSizeClipSpace / (pointRight.x / pointRight.w - gContext.mMVP.v.position.x / gContext.mMVP.v.position.w);
 
       vec_t rightViewInverse = viewInverse.v.right;
       rightViewInverse.TransformVector(gContext.mModelInverse);


### PR DESCRIPTION
the `mScreenFactor` calculation was unused anyway because the value got overwritten a few lines below without being used

see issue #280