### PR TITLE
Fixed warning introduced in 6614f455895a11b4d7644b21b29a90eadca397ee

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -666,7 +666,7 @@ namespace IMGUIZMO_NAMESPACE
 
    struct Context
    {
-      Context() : mbUsing(false), mbUsingViewManipulate(false), mbEnable(true), mbUsingBounds(false), mIsViewManipulatorHovered(false)
+      Context() : mbUsing(false), mbUsingViewManipulate(false), mbEnable(true), mIsViewManipulatorHovered(false), mbUsingBounds(false)
       {
 		  mIDStack.push_back(-1);
       }

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -140,6 +140,8 @@ namespace IMGUIZMO_NAMESPACE
 
    // return true if the view gizmo is in moving state
    IMGUI_API bool IsUsingViewManipulate();
+   // only check if your mouse is over the view manipulator - no matter whether it's active or not
+   IMGUI_API bool IsViewManipulateHovered();
 
    // return true if any gizmo is in moving state
    IMGUI_API bool IsUsingAny();
@@ -220,8 +222,6 @@ namespace IMGUIZMO_NAMESPACE
 
    // use this version if you did not call Manipulate before and you are just using ViewManipulate
    IMGUI_API void ViewManipulate(float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float length, ImVec2 position, ImVec2 size, ImU32 backgroundColor);
-   // only check if your mouse is over the view manipulator
-   IMGUI_API bool IsManipulatorHovered();
 
    IMGUI_API void SetAlternativeWindow(ImGuiWindow* window);
 


### PR DESCRIPTION
Field 'mbUsingBounds' will be initialized after field 'mIsViewManipulatorHovered' (fix available)clang(-Wreorder-ctor)