### PR TITLE
Added ResetOperation to fix IsOver() reporting

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2645,6 +2645,11 @@ namespace IMGUIZMO_NAMESPACE
       return radius < pixelRadius;
    }
 
+   void ResetOperation(OPERATION operation)
+   {
+      gContext.mOperation = operation;
+   }
+
    bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix, const float* snap, const float* localBounds, const float* boundsSnap)
    {
       gContext.mDrawList->PushClipRect (ImVec2 (gContext.mX, gContext.mY), ImVec2 (gContext.mX + gContext.mWidth, gContext.mY + gContext.mHeight), false);

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -179,6 +179,7 @@ namespace IMGUIZMO_NAMESPACE
    // translation is applied in world space
    enum OPERATION
    {
+      OP_NONE          = 0,
       TRANSLATE_X      = (1u << 0),
       TRANSLATE_Y      = (1u << 1),
       TRANSLATE_Z      = (1u << 2),
@@ -211,6 +212,8 @@ namespace IMGUIZMO_NAMESPACE
       LOCAL,
       WORLD
    };
+
+   IMGUI_API void ResetOperation(OPERATION operation = OP_NONE);
 
    IMGUI_API bool Manipulate(const float* view, const float* projection, OPERATION operation, MODE mode, float* matrix, float* deltaMatrix = NULL, const float* snap = NULL, const float* localBounds = NULL, const float* boundsSnap = NULL);
    //


### PR DESCRIPTION
Relates to/adds functionality to fix #132, #133, #310.

I've been noticing the same issue as these previous reports, where IsOver() is reporting true even when I'm not drawing a gizmo:
[gizmo.webm](https://github.com/user-attachments/assets/2308a11b-74f3-436c-bac9-aa92b4ae618e)

I've added a low-footprint fix to errant IsOver() return values when stopping gizmo drawing and having the mouse cursor over the spot where the gizmo would have been drawn. The key issue is out-of-path logic that stops gizmo drawing, since IsOver() uses cached operation flags from the last Manipulate call to decide if the mouse is over a gizmo, whether it's being drawn or not.

Adding the capability to (re)set the operation flag allows for the correct result from IsOver() without needing to send a call through Manipulate just to reset the flag. There was a suggestion in the previous reports that users could track the gizmo drawing state and use that in conjunction with IsOver(), but I think it's useful to have a way to correct the cached operation flag.