### PR TITLE
Fixed visual studio "int to bool" warnings.

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -1271,7 +1271,7 @@ namespace IMGUIZMO_NAMESPACE
       }
       ImDrawList* drawList = gContext.mDrawList;
 
-      bool isMultipleAxesMasked = gContext.mAxisMask & (gContext.mAxisMask - 1);
+      bool isMultipleAxesMasked = (gContext.mAxisMask & (gContext.mAxisMask - 1)) != 0;
       bool isNoAxesMasked = !gContext.mAxisMask;
 
       // colors
@@ -1302,7 +1302,7 @@ namespace IMGUIZMO_NAMESPACE
             continue;
          }
 
-         bool isAxisMasked = (1 << (2 - axis)) & gContext.mAxisMask;
+         bool isAxisMasked = ((1 << (2 - axis)) & gContext.mAxisMask) != 0;
 
          if ((!isAxisMasked || isMultipleAxesMasked) && !isNoAxesMasked)
          {
@@ -1944,7 +1944,7 @@ namespace IMGUIZMO_NAMESPACE
          {
             continue;
          }
-         bool isAxisMasked = (1 << i) & gContext.mAxisMask;
+         bool isAxisMasked = ((1 << i) & gContext.mAxisMask) != 0;
 
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
@@ -2018,7 +2018,7 @@ namespace IMGUIZMO_NAMESPACE
       }
 
       bool isNoAxesMasked = !gContext.mAxisMask;
-      bool isMultipleAxesMasked = gContext.mAxisMask & (gContext.mAxisMask - 1);
+      bool isMultipleAxesMasked = (gContext.mAxisMask & (gContext.mAxisMask - 1)) != 0;
 
       ImGuiIO& io = ImGui::GetIO();
       int type = MT_NONE;
@@ -2043,7 +2043,7 @@ namespace IMGUIZMO_NAMESPACE
          {
             continue;
          }
-         bool isAxisMasked = (1 << i) & gContext.mAxisMask;
+         bool isAxisMasked = ((1 << i) & gContext.mAxisMask) != 0;
          // pickup plan
          vec_t pickupPlan = BuildPlan(gContext.mModel.v.position, planNormals[i]);
 
@@ -2085,7 +2085,7 @@ namespace IMGUIZMO_NAMESPACE
       }
 
       bool isNoAxesMasked = !gContext.mAxisMask;
-      bool isMultipleAxesMasked = gContext.mAxisMask & (gContext.mAxisMask - 1);
+      bool isMultipleAxesMasked = (gContext.mAxisMask & (gContext.mAxisMask - 1)) != 0;
 
       ImGuiIO& io = ImGui::GetIO();
       int type = MT_NONE;
@@ -2103,7 +2103,7 @@ namespace IMGUIZMO_NAMESPACE
       // compute
       for (int i = 0; i < 3 && type == MT_NONE; i++)
       {
-         bool isAxisMasked = (1 << i) & gContext.mAxisMask;
+         bool isAxisMasked = ((1 << i) & gContext.mAxisMask) != 0;
          vec_t dirPlaneX, dirPlaneY, dirAxis;
          bool belowAxisLimit, belowPlaneLimit;
          ComputeTripodAxisAndVisibility(i, dirAxis, dirPlaneX, dirPlaneY, belowAxisLimit, belowPlaneLimit);


### PR DESCRIPTION
Getting the following warnings with Visual Studio 2015:
```
2>imguizmo.cpp(1274): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
2>imguizmo.cpp(1305): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
2>imguizmo.cpp(1947): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
2>imguizmo.cpp(2021): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
2>imguizmo.cpp(2046): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
2>imguizmo.cpp(2088): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
2>imguizmo.cpp(2106): warning C4800: 'int': forcing value to bool 'true' or 'false' (performance warning)
```
Using a explicit conversion seems like the best solution to me but you might choose instead to silence C4800.