### PR TITLE
Capture mouse when using ViewManipulate()

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -3137,7 +3137,7 @@ namespace IMGUIZMO_NAMESPACE
       }
 
       gContext.mbUsingViewManipulate = (interpolationFrames != 0) || isDraging;
-      if (isClicking || gContext.mbUsingViewManipulate) {
+      if (isClicking || gContext.mbUsingViewManipulate || gContext.mIsViewManipulatorHovered) {
 #if IMGUI_VERSION_NUM >= 18723
          ImGui::SetNextFrameWantCaptureMouse(true);
 #else

--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -3137,6 +3137,13 @@ namespace IMGUIZMO_NAMESPACE
       }
 
       gContext.mbUsingViewManipulate = (interpolationFrames != 0) || isDraging;
+      if (isClicking || gContext.mbUsingViewManipulate) {
+#if IMGUI_VERSION_NUM >= 18723
+         ImGui::SetNextFrameWantCaptureMouse(true);
+#else
+         ImGui::CaptureMouseFromApp();
+#endif
+      }
 
       // restore view/projection because it was used to compute ray
       ComputeContext(svgView.m16, svgProjection.m16, gContext.mModelSource.m16, gContext.mMode);


### PR DESCRIPTION
Currently mouse is captured when calling `Manipulate()`, but not for `ViewManipulate()`. I think the latter also have to capture the mouse for consistency.