### PR TITLE
Fix calculation in `SetRect`

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -960,7 +960,7 @@ namespace IMGUIZMO_NAMESPACE
       gContext.mWidth = width;
       gContext.mHeight = height;
       gContext.mXMax = gContext.mX + gContext.mWidth;
-      gContext.mYMax = gContext.mY + gContext.mXMax;
+      gContext.mYMax = gContext.mY + gContext.mHeight;
       gContext.mDisplayRatio = width / height;
    }
 


### PR DESCRIPTION
In `SetRect` the max Y value was calculated via `gContext.mY + gContext.mXMax`.
This doesn't make much sense to me and should probably be `gContext.mY + gContext.mHeight`.

In practice this issue was noticed because it made the BOUNDS gizmo not show up on monitors with negative screen coordinates.
e.g. on Windows this would be the monitor to the left of your main monitor.
Other gizmo modes were not affected.
