### PR TITLE
Fix EditTransform() example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,15 @@ Code for :
 ![Image of dialog](http://i.imgur.com/GL5flN1.png)
 
 ```C++
-void EditTransform(const Camera& camera, matrix_t& matrix)
+void EditTransform(float* cameraView, float* cameraProjection, float* matrix)
 {
     static ImGuizmo::OPERATION mCurrentGizmoOperation(ImGuizmo::ROTATE);
     static ImGuizmo::MODE mCurrentGizmoMode(ImGuizmo::WORLD);
-    if (ImGui::IsKeyPressed(90))
+    if (ImGui::IsKeyPressed(ImGuiKey_T))
         mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
-    if (ImGui::IsKeyPressed(69))
+    if (ImGui::IsKeyPressed(ImGuiKey_E))
         mCurrentGizmoOperation = ImGuizmo::ROTATE;
-    if (ImGui::IsKeyPressed(82)) // r Key
+    if (ImGui::IsKeyPressed(ImGuiKey_R))
         mCurrentGizmoOperation = ImGuizmo::SCALE;
     if (ImGui::RadioButton("Translate", mCurrentGizmoOperation == ImGuizmo::TRANSLATE))
         mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
@@ -136,11 +136,11 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
     if (ImGui::RadioButton("Scale", mCurrentGizmoOperation == ImGuizmo::SCALE))
         mCurrentGizmoOperation = ImGuizmo::SCALE;
     float matrixTranslation[3], matrixRotation[3], matrixScale[3];
-    ImGuizmo::DecomposeMatrixToComponents(matrix.m16, matrixTranslation, matrixRotation, matrixScale);
-    ImGui::InputFloat3("Tr", matrixTranslation, 3);
-    ImGui::InputFloat3("Rt", matrixRotation, 3);
-    ImGui::InputFloat3("Sc", matrixScale, 3);
-    ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, matrix.m16);
+    ImGuizmo::DecomposeMatrixToComponents(matrix, matrixTranslation, matrixRotation, matrixScale);
+    ImGui::InputFloat3("Tr", matrixTranslation);
+    ImGui::InputFloat3("Rt", matrixRotation);
+    ImGui::InputFloat3("Sc", matrixScale);
+    ImGuizmo::RecomposeMatrixFromComponents(matrixTranslation, matrixRotation, matrixScale, matrix);
 
     if (mCurrentGizmoOperation != ImGuizmo::SCALE)
     {
@@ -151,9 +151,9 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
             mCurrentGizmoMode = ImGuizmo::WORLD;
     }
     static bool useSnap(false);
-    if (ImGui::IsKeyPressed(83))
+    if (ImGui::IsKeyPressed(ImGuiKey_S))
         useSnap = !useSnap;
-    ImGui::Checkbox("", &useSnap);
+    ImGui::Checkbox("##useSnap", &useSnap);
     ImGui::SameLine();
     vec_t snap;
     switch (mCurrentGizmoOperation)
@@ -170,10 +170,12 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
         snap = config.mSnapScale;
         ImGui::InputFloat("Scale Snap", &snap.x);
         break;
+    default:
+        break;
     }
     ImGuiIO& io = ImGui::GetIO();
     ImGuizmo::SetRect(0, 0, io.DisplaySize.x, io.DisplaySize.y);
-    ImGuizmo::Manipulate(camera.mView.m16, camera.mProjection.m16, mCurrentGizmoOperation, mCurrentGizmoMode, matrix.m16, NULL, useSnap ? &snap.x : NULL);
+    ImGuizmo::Manipulate(cameraView, cameraProjection, mCurrentGizmoOperation, mCurrentGizmoMode, matrix, NULL, useSnap ? &snap.x : NULL);
 }
 ```
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -243,7 +243,7 @@ void TransformStart(float* cameraView, float* cameraProjection, float* matrix)
 
     if (ImGui::IsKeyPressed(ImGuiKey_S))
         useSnap = !useSnap;
-    ImGui::Checkbox(" ", &useSnap);
+    ImGui::Checkbox("##useSnap", &useSnap);
     ImGui::SameLine();
     switch (mCurrentGizmoOperation)
     {


### PR DESCRIPTION
The previous example code in the README would not compile with latest ImGui. This PR fixes the example in the README and makes it more closely align with the code in the example folder.

I discovered this issue when trying to copy and paste from the README into my own game so wanted to share the fix so others can get up and running quickly.

- Update ImGui::IsKeyPressed() to match latest API
- Update ImGui::InputFloat3() to match latest API
- Add ID to ImGui::Checkbox() call (not having this triggers an assert)
- Add default: case to avoid warning
- Change arguments to be more generic & align with example code