### PR TITLE
Add option to draw origin axes via DrawAxes function

### DIFF
--- a/ImGuizmo.cpp
+++ b/ImGuizmo.cpp
@@ -2752,6 +2752,86 @@ namespace IMGUIZMO_NAMESPACE
          frustum[i].Normalize();
       }
    }
+   
+   void DrawAxes(const float* view, const float* projection, const float* matrices, int matrixCount)
+   {
+      matrix_t viewM = *(matrix_t*)view;
+      matrix_t projM = *(matrix_t*)projection;
+      matrix_t viewProj = viewM * projM;
+
+      // build frustum
+      vec_t frustum[6];
+      ComputeFrustumPlanes(frustum, viewProj.m16);
+
+      for (int i = 0; i < matrixCount; i++)
+      {
+         const float* matrix = &matrices[i * 16];
+         matrix_t model = *(matrix_t*)matrix;
+         matrix_t mvp = model * viewProj;
+
+         // world-space origin
+         vec_t origin;
+         origin.TransformPoint(vec_t(0.f, 0.f, 0.f), model);
+
+         struct Axis
+         {
+               vec_t dir;
+               ImU32 color;
+         };
+
+         Axis axes[3] = {
+               { vec_t(1.f, 0.f, 0.f), IM_COL32(255, 0, 0, 255) }, // X - red
+               { vec_t(0.f, 1.f, 0.f), IM_COL32(0, 255, 0, 255) }, // Y - green
+               { vec_t(0.f, 0.f, 1.f), IM_COL32(0, 0, 255, 255) }  // Z - blue
+         };
+
+         for (int a = 0; a < 3; a++)
+         {
+               vec_t endLocal = axes[a].dir;
+
+               // world-space endpoint
+               vec_t end;
+               end.TransformPoint(endLocal, model);
+
+               // frustum test
+               bool visible = true;
+               for (int f = 0; f < 6; f++)
+               {
+                  float d0 = DistanceToPlane(origin, frustum[f]);
+                  float d1 = DistanceToPlane(end, frustum[f]);
+
+                  // both outside - reject
+                  if (d0 < 0.f && d1 < 0.f)
+                  {
+                     visible = false;
+                     break;
+                  }
+               }
+
+               if (!visible)
+               {
+                  continue;
+               }
+
+               // project to screen
+               ImVec2 p0 = worldToPos(vec_t(0.f, 0.f, 0.f), mvp);
+               ImVec2 p1 = worldToPos(endLocal, mvp);
+
+               // reject behind camera (clip space)
+               vec_t clip0, clip1;
+               clip0.TransformPoint(vec_t(0.f, 0.f, 0.f), mvp);
+               clip1.TransformPoint(endLocal, mvp);
+
+               if (clip0.w <= 0.f && clip1.w <= 0.f)
+               {
+                  continue;
+               }
+
+               // draw
+               gContext.mDrawList->AddLine(p0, p1, axes[a].color, 2.0f);
+         }
+      }
+   }
 
    void DrawCubes(const float* view, const float* projection, const float* matrices, int matrixCount)
    {

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -170,6 +170,7 @@ namespace IMGUIZMO_NAMESPACE
    IMGUI_API void SetOrthographic(bool isOrthographic);
 
    // Render a cube with face color corresponding to face normal. Usefull for debug/tests
+   IMGUI_API void DrawAxes(const float* view, const float* projection, const float* matrices, int matrixCount);
    IMGUI_API void DrawCubes(const float* view, const float* projection, const float* matrices, int matrixCount);
    IMGUI_API void DrawGrid(const float* view, const float* projection, const float* matrix, const float gridSize);
 

--- a/ImGuizmo.h
+++ b/ImGuizmo.h
@@ -169,8 +169,9 @@ namespace IMGUIZMO_NAMESPACE
    // default is false
    IMGUI_API void SetOrthographic(bool isOrthographic);
 
-   // Render a cube with face color corresponding to face normal. Usefull for debug/tests
+   // Render coordinate system axes (red X, green Y and blue Z). Usefull for debug/tests
    IMGUI_API void DrawAxes(const float* view, const float* projection, const float* matrices, int matrixCount);
+   // Render a cube with face color corresponding to face normal. Usefull for debug/tests
    IMGUI_API void DrawCubes(const float* view, const float* projection, const float* matrices, int matrixCount);
    IMGUI_API void DrawGrid(const float* view, const float* projection, const float* matrix, const float gridSize);
 


### PR DESCRIPTION
Recently I was building some CAD-like applications and I was lacking an option do quickly draw origin axes (mainly for the origin but also to indicate object orientation in space or on some path). ImGuizmo already can draw axes while drawing translation guizmos but there was no option to draw indicator only axes.

``` cpp
        ImGuizmo::DrawGrid(
            glm::value_ptr(view_camera),
            glm::value_ptr(projection),
            glm::value_ptr(identity),
            100.0f);

        glm::mat4 tests[] = {
            glm::identity<glm::mat4>(),
            glm::translate(glm::identity<glm::mat4>(), glm::vec3(3, 0, 1)),
            glm::translate(glm::identity<glm::mat4>(), glm::vec3(-3, 0, -1)) * glm::scale(glm::identity<glm::mat4>(), glm::vec3(2.0, 1.0, 0.5)),
            glm::translate(glm::identity<glm::mat4>(), glm::vec3(-2, 2, -1)) * glm::rotate(glm::identity<glm::mat4>(), glm::quarter_pi<float>(), glm::vec3(0.0f, 0.0f, 1.0f))};

        ImGuizmo::DrawAxes(
            glm::value_ptr(view_camera),
            glm::value_ptr(projection),
            glm::value_ptr(tests[0]), std::size(tests));
```

On the image - second axes are origin. Image is the result of what code snippet pasted above draws.

<img width="1912" height="1065" alt="image" src="https://github.com/user-attachments/assets/732b0d71-765e-4110-92cc-92f6e136be29" />
