### PR TITLE
Add clipping for DrawCubes

### DIFF
--- a/src/ImGuizmo.cpp
+++ b/src/ImGuizmo.cpp
@@ -2872,36 +2872,17 @@ namespace IMGUIZMO_NAMESPACE
             const int perpYIndex = (normalIndex + 2) % 3;
             const float invert = (iFace > 2) ? -1.f : 1.f;
 
-            const vec_t faceCoords[4] = { directionUnary[normalIndex] + directionUnary[perpXIndex] + directionUnary[perpYIndex],
+            const vec_t faceCoords[4] =
+            {
+               directionUnary[normalIndex] + directionUnary[perpXIndex] + directionUnary[perpYIndex],
                directionUnary[normalIndex] + directionUnary[perpXIndex] - directionUnary[perpYIndex],
                directionUnary[normalIndex] - directionUnary[perpXIndex] - directionUnary[perpYIndex],
                directionUnary[normalIndex] - directionUnary[perpXIndex] + directionUnary[perpYIndex],
             };
 
             // clipping
-            /*
-            bool skipFace = false;
-            for (unsigned int iCoord = 0; iCoord < 4; iCoord++)
-            {
-               vec_t camSpacePosition;
-               camSpacePosition.TransformPoint(faceCoords[iCoord] * 0.5f * invert, res);
-               if (camSpacePosition.z < 0.001f)
-               {
-                  skipFace = true;
-                  break;
-               }
-            }
-            if (skipFace)
-            {
-               continue;
-            }
-            */
-            vec_t centerPosition, centerPositionVP;
-            centerPosition.TransformPoint(directionUnary[normalIndex] * 0.5f * invert, *(matrix_t*)matrix);
-            centerPositionVP.TransformPoint(directionUnary[normalIndex] * 0.5f * invert, res);
-
             bool inFrustum = true;
-            for (int iFrustum = 0; iFrustum < 6; iFrustum++)
+            for (unsigned int iFrustum = 0; iFrustum < 6; iFrustum++)
             {
                const vec_t& plane = frustum[iFrustum];
 
@@ -2921,7 +2902,8 @@ namespace IMGUIZMO_NAMESPACE
 
                if (allOutside)
                {
-                  continue; // face is fully outside this plane - discard
+                  inFrustum = false;
+                  break;
                }
             }
 
@@ -2940,6 +2922,9 @@ namespace IMGUIZMO_NAMESPACE
 
             ImU32 directionColor = GetColorU32(DIRECTION_X + normalIndex);
             cubeFace.color = directionColor | IM_COL32(0x80, 0x80, 0x80, 0);
+
+            vec_t centerPositionVP;
+            centerPositionVP.TransformPoint(directionUnary[normalIndex] * 0.5f * invert, res);
 
             cubeFace.z = centerPositionVP.z / centerPositionVP.w;
             cubeFaceCount++;


### PR DESCRIPTION
Current master:

<img width="2455" height="1164" alt="image" src="https://github.com/user-attachments/assets/3ba62bf6-edec-4e9f-81d4-26c4973d26d8" />

<img width="2408" height="1113" alt="image" src="https://github.com/user-attachments/assets/e3ddfc38-71f3-4350-b5e0-41f7eca5dd1f" />

After changes:

<img width="2448" height="1172" alt="image" src="https://github.com/user-attachments/assets/459808f6-cc01-4638-9dc7-9e64e7bc714a" />

<img width="2442" height="1138" alt="image" src="https://github.com/user-attachments/assets/c019a440-b01e-4d4a-b596-92165f72f38e" />
