### PR TITLE
fixes for ImGui v1.92.8: DrawList: swapped the last two arguments of AddRect(), AddPolyline(), PathStroke()

### DIFF
--- a/src/GraphEditor.cpp
+++ b/src/GraphEditor.cpp
@@ -276,7 +276,11 @@ static void DisplayLinks(Delegate& delegate,
             float highLightFactor = factor * (highlightCons ? 2.0f : 1.f);
             for (int pass = 0; pass < 2; pass++)
             {
+#if IMGUI_VERSION_NUM < 19276
                 drawList->AddPolyline(pts.data(), ptCount, pass ? col : 0xFF000000, false, (pass ? options.mLineThickness : (options.mLineThickness * 1.5f)) * highLightFactor);
+#else
+                drawList->AddPolyline(pts.data(), ptCount, pass ? col : 0xFF000000, (pass ? options.mLineThickness : (options.mLineThickness * 1.5f)) * highLightFactor);
+#endif
             }
         }
     }
@@ -627,12 +631,21 @@ static bool DrawNode(ImDrawList* drawList,
     const bool currentSelectedNode = node.mSelected;
     const ImU32 node_bg_color = nodeHovered ? nodeTemplate.mBackgroundColorOver : nodeTemplate.mBackgroundColor;
 
+#if IMGUI_VERSION_NUM < 19276
     drawList->AddRect(nodeRectangleMin,
                       nodeRectangleMax,
                       currentSelectedNode ? options.mSelectedNodeBorderColor : options.mNodeBorderColor,
                       options.mRounding,
                       ImDrawFlags_RoundCornersAll,
                       currentSelectedNode ? options.mBorderSelectionThickness : options.mBorderThickness);
+#else
+    drawList->AddRect(nodeRectangleMin,
+                      nodeRectangleMax,
+                      currentSelectedNode ? options.mSelectedNodeBorderColor : options.mNodeBorderColor,
+                      options.mRounding,
+                      currentSelectedNode ? options.mBorderSelectionThickness : options.mBorderThickness,
+                      ImDrawFlags_RoundCornersAll);
+#endif
 
     ImVec2 imgPos = nodeRectangleMin + ImVec2(14, 25);
     ImVec2 imgSize = nodeRectangleMax + ImVec2(-5, -5) - imgPos;
@@ -878,7 +891,11 @@ void Show(Delegate& delegate, const Options& options, ViewState& viewState, bool
         // Focus rectangle
         if (ImGui::IsWindowFocused())
         {
+#if IMGUI_VERSION_NUM < 19276
            drawList->AddRect(regionRect.Min, regionRect.Max, options.mFrameFocus, 1.f, 0, 2.f);
+#else
+           drawList->AddRect(regionRect.Min, regionRect.Max, options.mFrameFocus, 1.f, 2.f);
+#endif
         }
 
         drawList->ChannelsSetCurrent(1); // Background

--- a/src/ImCurveEdit.cpp
+++ b/src/ImCurveEdit.cpp
@@ -123,13 +123,21 @@ namespace ImCurveEdit
          if (io.MouseDown[0])
             ret = 2;
       }
+#if IMGUI_VERSION_NUM < 19276
       if (edited)
          draw_list->AddPolyline(offsets, 4, 0xFFFFFFFF, true, 3.0f);
       else if (ret)
          draw_list->AddPolyline(offsets, 4, 0xFF80B0FF, true, 2.0f);
       else
          draw_list->AddPolyline(offsets, 4, 0xFF0080FF, true, 2.0f);
-
+#else
+      if (edited)
+         draw_list->AddPolyline(offsets, 4, 0xFFFFFFFF,  3.0f);
+      else if (ret)
+         draw_list->AddPolyline(offsets, 4, 0xFF80B0FF, 2.0f);
+      else
+         draw_list->AddPolyline(offsets, 4, 0xFF0080FF, 2.0f);
+#endif
       return ret;
    }
 

--- a/src/ImGradient.cpp
+++ b/src/ImGradient.cpp
@@ -48,10 +48,17 @@ namespace ImGradient
 
       color.w = 1.f;
       draw_list->AddRectFilled(p1, p2, ImColor(color));
+#if IMGUI_VERSION_NUM < 19276
       if (editing)
          draw_list->AddRect(p1, p2, 0xFFFFFFFF, 2.f, 15, 2.5f);
       else
          draw_list->AddRect(p1, p2, 0x80FFFFFF, 2.f, 15, 1.25f);
+#else
+      if (editing)
+         draw_list->AddRect(p1, p2, 0xFFFFFFFF, 2.f, 2.5f);
+      else
+         draw_list->AddRect(p1, p2, 0x80FFFFFF, 2.f, 1.25f);
+#endif
 
       if (rc.Contains(io.MousePos))
       {


### PR DESCRIPTION
See https://github.com/ocornut/imgui/releases/tag/v1.92.8

"DrawList: swapped the last two arguments of AddRect(), AddPolyline(), PathStroke()"

Gate the affected call sites on IMGUI_VERSION_NUM < 19276: last two args (flags, thickness) were swapped to (thickness, flags)
