### PR TITLE
Fix for dissappearing axis when using a translation axis

### DIFF
--- a/src/ImGuizmo.cpp
+++ b/src/ImGuizmo.cpp
@@ -1200,7 +1200,7 @@ namespace IMGUIZMO_NAMESPACE
          // when using, use stored factors so the gizmo doesn't flip when we translate
 
          // Apply axis mask to axes and planes
-         belowAxisLimit = gContext.mBelowAxisLimit[axisIndex] && ((1<<axisIndex)&gContext.mAxisMask);
+         belowAxisLimit = gContext.mBelowAxisLimit[axisIndex] && !((1<<axisIndex)&gContext.mAxisMask);
          belowPlaneLimit = gContext.mBelowPlaneLimit[axisIndex] && (((1<<axisIndex) == gContext.mAxisMask) || !gContext.mAxisMask);
 
          dirAxis *= gContext.mAxisFactor[axisIndex];


### PR DESCRIPTION
The calculation for the return parameter `belowAxisLimit` when not using an axis is:

`belowAxisLimit = (axisLengthInClipSpace > gContext.mPlaneLimit) && !((1<<axisIndex)&gContext.mAxisMask);`

However when using the calculation is:

`belowAxisLimit = gContext.mBelowAxisLimit[axisIndex] && ((1<<axisIndex)&gContext.mAxisMask);`

Which is missing a `!`. This can cause the axis to disappear when using it.