### PR TITLE
Fixes for IsOver not working for SCALEU operations

### DIFF
--- a/src/ImGuizmo.cpp
+++ b/src/ImGuizmo.cpp
@@ -1024,7 +1024,7 @@ namespace IMGUIZMO_NAMESPACE
    {
       return (Intersects(gContext.mOperation, TRANSLATE) && GetMoveType(gContext.mOperation, NULL) != MT_NONE) ||
          (Intersects(gContext.mOperation, ROTATE) && GetRotateType(gContext.mOperation) != MT_NONE) ||
-         (Intersects(gContext.mOperation, SCALE) && GetScaleType(gContext.mOperation) != MT_NONE) || IsUsing();
+         (Intersects(gContext.mOperation, SCALE | SCALEU) && GetScaleType(gContext.mOperation) != MT_NONE) || IsUsing();
    }
 
    bool IsOver(OPERATION op)
@@ -1033,7 +1033,7 @@ namespace IMGUIZMO_NAMESPACE
       {
          return true;
       }
-      if(Intersects(op, SCALE) && GetScaleType(op) != MT_NONE)
+      if(Intersects(op, SCALE | SCALEU) && GetScaleType(op) != MT_NONE)
       {
          return true;
       }


### PR DESCRIPTION
I found that `SCALEU` was not setting IsOver() to true when the handles were hovered over, and checking the code I saw that only the `SCALE` bits (7-9) were being checked and not `SCALEU` (11-13).

This PR adds the simple fix.

I also think `BOUNDS` is not being checked, but don't have a fix for that as I'm unsure how to check it.