### PR TITLE
Add IMGUIZMO_DONT_INCLUDE_IMGUI to solve issues with duplicated inclusion of imgui/imgui_internal headers

### DIFF
--- a/src/GraphEditor.h
+++ b/src/GraphEditor.h
@@ -28,8 +28,10 @@
 #include <vector>
 #include <stdint.h>
 #include <string>
+#ifndef IMGUIZMO_DONT_INCLUDE_IMGUI
 #include "imgui.h"
 #include "imgui_internal.h"
+#endif
 
 namespace GraphEditor {
 

--- a/src/ImCurveEdit.h
+++ b/src/ImCurveEdit.h
@@ -25,7 +25,9 @@
 //
 #pragma once
 #include <stdint.h>
+#ifndef IMGUIZMO_DONT_INCLUDE_IMGUI
 #include "imgui.h"
+#endif
 
 struct ImRect;
 

--- a/src/ImGuizmo.h
+++ b/src/ImGuizmo.h
@@ -106,7 +106,9 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 #pragma once
 
 #ifdef USE_IMGUI_API
+#ifndef IMGUIZMO_DONT_INCLUDE_IMGUI
 #include "imconfig.h"
+#endif
 #endif
 #ifndef IMGUI_API
 #define IMGUI_API

--- a/src/ImLightRig.h
+++ b/src/ImLightRig.h
@@ -1,5 +1,7 @@
 #pragma once
+#ifndef IMGUIZMO_DONT_INCLUDE_IMGUI
 #include "imgui.h"
+#endif
 
 namespace ImLightRig
 {

--- a/src/ImVectorEditor.h
+++ b/src/ImVectorEditor.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifndef IMGUIZMO_DONT_INCLUDE_IMGUI
 #include "imgui.h"
+#endif
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
the issue i have stumbled upon in my project is that i am building imgui on my own to create shared library instead of static. the problem is that then imguizmo uses headers from vcpkg and mine imgui uses headers from diffrent directory which makes #pragma once not ommit second header. This leads to redeclaration and build errors.

Fix?

Add check if macro IMGUIZMO_DONT_INCLUDE_IMGUI is NOT present so it won't affect anybody unless someone explicitly doesn't want imuizmo to include imgui.

Example:

#ifndef IMGUIZMO_DONT_INCLUDE_IMGUI
#include "imgui.h"
#include "imgui_internal.h"
#endif